### PR TITLE
feat: add menu item icons

### DIFF
--- a/TypeSwitch/Sources/UI/Views/MenuBar/AppInfoView.swift
+++ b/TypeSwitch/Sources/UI/Views/MenuBar/AppInfoView.swift
@@ -9,14 +9,16 @@ struct AppInfoView: View {
             Button {
                 AppInfoService.openGitHubRepository()
             } label: {
-                Text(verbatim: "GitHub")
+                Label("GitHub", systemImage: "link")
             }
 
             Divider()
 
             // 退出应用
-            Button(TypeSwitchStrings.Menu.quit, role: .destructive) {
+            Button(role: .destructive) {
                 NSApplication.shared.terminate(nil)
+            } label: {
+                Label(TypeSwitchStrings.Menu.quit, systemImage: "power")
             }
             .keyboardShortcut("q", modifiers: .command)
         }

--- a/TypeSwitch/Sources/UI/Views/MenuBar/ConfiguredAppsView.swift
+++ b/TypeSwitch/Sources/UI/Views/MenuBar/ConfiguredAppsView.swift
@@ -8,9 +8,9 @@ struct ConfiguredAppsView: View {
     var body: some View {
         if !store.configuredApps.isEmpty {
             Section {
-                Menu(TypeSwitchStrings.Apps.Section.configuredCount(store.configuredApps.count)) {
+                Menu {
                     if store.hasMissingInputMethodRules {
-                        Button(TypeSwitchStrings.InputMethod.clearMissingConfiguration, role: .destructive) {
+                        Button(role: .destructive) {
                             if MenuConfirmation.confirm(
                                 title: TypeSwitchStrings.InputMethod.ClearMissingConfirmation.title,
                                 message: TypeSwitchStrings.InputMethod.ClearMissingConfirmation.message,
@@ -18,6 +18,11 @@ struct ConfiguredAppsView: View {
                             ) {
                                 store.send(.view(.removeMissingInputMethodRulesTapped))
                             }
+                        } label: {
+                            Label(
+                                TypeSwitchStrings.InputMethod.clearMissingConfiguration,
+                                systemImage: "trash"
+                            )
                         }
 
                         Divider()
@@ -31,6 +36,11 @@ struct ConfiguredAppsView: View {
                             store.send(.view(.setStrategy(bundleId: item.bundleId, strategy: strategy)))
                         }
                     }
+                } label: {
+                    Label(
+                        TypeSwitchStrings.Apps.Section.configuredCount(store.configuredApps.count),
+                        systemImage: "list.bullet.rectangle"
+                    )
                 }
             }
         }

--- a/TypeSwitch/Sources/UI/Views/MenuBar/MenuBarView.swift
+++ b/TypeSwitch/Sources/UI/Views/MenuBar/MenuBarView.swift
@@ -27,6 +27,7 @@ struct MenuBarView: View {
 
             AppInfoView()
         }
+        .labelStyle(.titleAndIcon)
     }
 }
 

--- a/TypeSwitch/Sources/UI/Views/MenuBar/SettingsView.swift
+++ b/TypeSwitch/Sources/UI/Views/MenuBar/SettingsView.swift
@@ -20,7 +20,10 @@ struct SettingsView: View {
                     store.send(.view(.setFallbackStrategy(strategy)))
                 }
             } label: {
-                Text(TypeSwitchStrings.Settings.Fallback.defaultInputMethod)
+                Label(
+                    TypeSwitchStrings.Settings.Fallback.defaultInputMethod,
+                    systemImage: "keyboard"
+                )
                 if let selectedLabel = store.fallbackSelectedLabel {
                     Text(selectedLabel)
                         .foregroundStyle(store.fallbackHasMissingInputMethod ? .secondary : .primary)
@@ -41,13 +44,20 @@ struct SettingsView: View {
                     .font(.footnote)
                     .foregroundStyle(.secondary)
 
-                Button(TypeSwitchStrings.Settings.General.openLoginItems) {
+                Button {
                     LaunchAtLoginService.openSystemSettingsLoginItems()
+                } label: {
+                    Label(TypeSwitchStrings.Settings.General.openLoginItems, systemImage: "gear")
                 }
             }
 
-            Button(TypeSwitchStrings.Settings.General.checkForUpdates) {
+            Button {
                 updaterController.checkForUpdates(nil)
+            } label: {
+                Label(
+                    TypeSwitchStrings.Settings.General.checkForUpdates,
+                    systemImage: "arrow.triangle.2.circlepath"
+                )
             }
         }
     }

--- a/TypeSwitch/Sources/UI/Views/MenuBar/SwitchStatisticsView.swift
+++ b/TypeSwitch/Sources/UI/Views/MenuBar/SwitchStatisticsView.swift
@@ -6,7 +6,7 @@ struct SwitchStatisticsView: View {
 
     var body: some View {
         Section {
-            Menu(TypeSwitchStrings.SwitchStatistics.menuTitle(store.totalSuccessfulSwitchCount)) {
+            Menu {
                 if store.switchStatisticsItems.isEmpty {
                     Text(TypeSwitchStrings.SwitchStatistics.empty)
                         .foregroundStyle(.secondary)
@@ -24,7 +24,7 @@ struct SwitchStatisticsView: View {
 
                     Divider()
 
-                    Button(TypeSwitchStrings.SwitchStatistics.clear, role: .destructive) {
+                    Button(role: .destructive) {
                         if MenuConfirmation.confirm(
                             title: TypeSwitchStrings.SwitchStatistics.ClearConfirmation.title,
                             message: TypeSwitchStrings.SwitchStatistics.ClearConfirmation.message,
@@ -32,8 +32,15 @@ struct SwitchStatisticsView: View {
                         ) {
                             store.send(.view(.clearSwitchStatisticsTapped))
                         }
+                    } label: {
+                        Label(TypeSwitchStrings.SwitchStatistics.clear, systemImage: "trash")
                     }
                 }
+            } label: {
+                Label(
+                    TypeSwitchStrings.SwitchStatistics.menuTitle(store.totalSuccessfulSwitchCount),
+                    systemImage: "chart.bar"
+                )
             }
         }
     }

--- a/TypeSwitch/Sources/UI/Views/MenuBar/UnavailableAppsView.swift
+++ b/TypeSwitch/Sources/UI/Views/MenuBar/UnavailableAppsView.swift
@@ -7,8 +7,8 @@ struct UnavailableAppsView: View {
     var body: some View {
         if !store.unavailableApps.isEmpty {
             Section {
-                Menu(TypeSwitchStrings.Apps.Section.unavailableCount(store.unavailableApps.count)) {
-                    Button(TypeSwitchStrings.Apps.clearUnavailable, role: .destructive) {
+                Menu {
+                    Button(role: .destructive) {
                         if MenuConfirmation.confirm(
                             title: TypeSwitchStrings.Apps.ClearUnavailableConfirmation.title,
                             message: TypeSwitchStrings.Apps.ClearUnavailableConfirmation.message,
@@ -16,6 +16,8 @@ struct UnavailableAppsView: View {
                         ) {
                             store.send(.view(.removeUnavailableRulesTapped))
                         }
+                    } label: {
+                        Label(TypeSwitchStrings.Apps.clearUnavailable, systemImage: "trash")
                     }
 
                     Divider()
@@ -28,6 +30,11 @@ struct UnavailableAppsView: View {
                             store.send(.view(.setStrategy(bundleId: item.bundleId, strategy: strategy)))
                         }
                     }
+                } label: {
+                    Label(
+                        TypeSwitchStrings.Apps.Section.unavailableCount(store.unavailableApps.count),
+                        systemImage: "exclamationmark.triangle"
+                    )
                 }
             }
         }


### PR DESCRIPTION
## Why

Several menu items lacked visual cues, making high-level submenus and common actions slower to scan. The project supports macOS 14, so native SF Symbols can improve clarity without adding image assets or changing menu behavior.

## What Changed

- Added SF Symbols to the default input method, configured apps, unavailable apps, and switch statistics menus.
- Added icons to clear, login item settings, update check, GitHub, and quit actions.
- Applied `.labelStyle(.titleAndIcon)` at the menu root so SwiftUI displays the new icons while preserving existing app icons, selection checkmarks, shortcuts, destructive roles, and menu structure.

## Verification

- `tuist test --no-selective-testing`: 63 tests passed, 0 failures.
