### PR TITLE
fix(launch-at-login): clean up fallback after approval

### DIFF
--- a/TypeSwitch/Sources/Services/System/LaunchAtLoginService.swift
+++ b/TypeSwitch/Sources/Services/System/LaunchAtLoginService.swift
@@ -43,6 +43,9 @@ enum LaunchAtLoginService {
 
         switch environment.serviceManagementStatus() {
         case .enabled:
+            if fallbackEnabled {
+                removeFallbackLaunchAgent(environment: environment)
+            }
             return .enabled
         case .notRegistered:
             return fallbackEnabled ? .enabled : .disabled

--- a/TypeSwitchTests/LaunchAtLoginServiceTests.swift
+++ b/TypeSwitchTests/LaunchAtLoginServiceTests.swift
@@ -14,6 +14,26 @@ final class LaunchAtLoginServiceTests: XCTestCase {
         XCTAssertEqual(status, .enabled)
     }
 
+    func testStatusRemovesFallbackWhenServiceManagementIsEnabled() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+        try fixture.writeLaunchAgent(executablePath: fixture.executableURL.path)
+        var launchctlCalls: [[String]] = []
+
+        let status = LaunchAtLoginService.status(
+            environment: fixture.environment(
+                serviceManagementStatus: { .enabled },
+                runLaunchctl: { arguments in
+                    launchctlCalls.append(arguments)
+                }
+            )
+        )
+
+        XCTAssertEqual(status, .enabled)
+        XCTAssertEqual(launchctlCalls, [["bootout", "gui/501", fixture.plistURL.path]])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.plistURL.path))
+    }
+
     func testStatusIgnoresFallbackLaunchAgentWithStaleExecutablePath() throws {
         let fixture = try Fixture()
         defer { fixture.cleanUp() }


### PR DESCRIPTION
## Why

When TypeSwitch previously installed the `LaunchAgent` fallback because `SMAppService` required approval, approving the native login item later could leave both startup mechanisms active. The startup status refresh reported the native service as enabled but did not remove the matching fallback.

## What Changed

- Remove the matching `LaunchAgent` fallback when startup status synchronization finds `SMAppService` already enabled.
- Add a regression test that verifies `bootout` is invoked and the fallback plist is deleted during this state transition.

## Verification

- The new regression test failed before the production change because no `bootout` occurred and the plist remained.
- Full test suite passes: 74 tests, 0 failures.
