### PR TITLE
docs: align README header styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 
 <h1 align="center">TypeSwitch</h1>
 
-<hr>
-
 <p align="center">TypeSwitch is a macOS menu bar utility for switching input methods per app. Choose how each app should behave, set the rule for unconfigured apps, and let TypeSwitch switch to the right input method when the frontmost app changes.</p>
 
 <p align="center">
@@ -21,7 +19,7 @@
   <a href="https://github.com/ygsgdbd/TypeSwitch/pulls"><img alt="PRs Welcome" src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg"></a>
 </p>
 
-<p align="center"><a href="README.zh-CN.md">简体中文</a> • <strong>English</strong></p>
+<p align="center">🇨🇳 <a href="README.zh-CN.md">简体中文</a> · 🇺🇸 <strong>English</strong></p>
 
 ## Screenshots
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,8 +8,6 @@
 
 <h1 align="center">TypeSwitch</h1>
 
-<hr>
-
 <p align="center">TypeSwitch 是一款按 App 自动切换输入法的 macOS 菜单栏工具。为每个 App 选择输入法策略，设置未配置应用规则，并在前台 App 切换时自动切到对应输入法。</p>
 
 <p align="center">
@@ -21,7 +19,7 @@
   <a href="https://github.com/ygsgdbd/TypeSwitch/pulls"><img alt="PRs Welcome" src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg"></a>
 </p>
 
-<p align="center"><strong>简体中文</strong> • <a href="README.md">English</a></p>
+<p align="center">🇨🇳 <strong>简体中文</strong> · 🇺🇸 <a href="README.md">English</a></p>
 
 ## 截图预览
 


### PR DESCRIPTION
## Why

The TypeSwitch README header rendered an extra thick divider compared with ListenBar, and its language switcher lacked the country markers used by the related project.

## What Changed

- Removed the explicit header divider from the English and Simplified Chinese READMEs.
- Added Chinese and US flag markers to both language switchers while preserving the existing links and adaptive app icon.
