### PR TITLE
[codex] Update Homebrew tap trust instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,37 @@
 
 ### Homebrew
 
+The `brew trust` command first shipped with Homebrew 5.1.15 on June 3, 2026. In Homebrew 5.1.15 through 5.x, trust was required only when `HOMEBREW_REQUIRE_TAP_TRUST=1` was set. Starting with Homebrew 6.0.0 on June 11, 2026, casks from non-official taps require explicit trust by default.
+
 ```bash
-brew install ygsgdbd/tap/typeswitch --cask
+brew tap ygsgdbd/tap
+brew trust --cask ygsgdbd/tap/typeswitch
+brew install --cask typeswitch
 ```
+
+This trusts only the `typeswitch` cask, not the entire tap. Homebrew stores the trust entry, so you normally need to run the trust command only once. See Homebrew's [Tap Trust documentation](https://docs.brew.sh/Tap-Trust) for details.
+
+Homebrew 5.1.14 and earlier do not have `brew trust` and do not require it:
+
+```bash
+brew tap ygsgdbd/tap
+brew install --cask typeswitch
+```
+
+If `brew trust` reports `Unknown command: trust`, skip that command or run `brew update` to upgrade Homebrew.
 
 Update Homebrew installations with:
 
 ```bash
 brew upgrade typeswitch
 ```
+
+#### Tap Trust Troubleshooting
+
+- If Homebrew reports `Refusing to load cask ... from untrusted tap`, run `brew trust --cask ygsgdbd/tap/typeswitch`, then retry the installation or upgrade.
+- If `brew doctor` reports that `ygsgdbd/tap` is untrusted, trust only the TypeSwitch cask with the command above; trusting the entire tap is not required.
+- If an existing installation stops upgrading after Homebrew is updated to 6.0.0 or later, trust the cask and retry `brew upgrade typeswitch`.
+- To trust every current and future formula, cask, and external command in the tap, use `brew trust ygsgdbd/tap`. This grants broader access and is not the recommended option.
 
 ### Manual Installation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -52,15 +52,37 @@
 
 ### Homebrew
 
+`brew trust` 命令首次随 Homebrew 5.1.15 于 2026 年 6 月 3 日发布。在 Homebrew 5.1.15–5.x 中，只有设置了 `HOMEBREW_REQUIRE_TAP_TRUST=1` 才会要求信任。从 2026 年 6 月 11 日发布的 Homebrew 6.0.0 开始，默认要求显式信任非官方 tap 中的 cask。
+
 ```bash
-brew install ygsgdbd/tap/typeswitch --cask
+brew tap ygsgdbd/tap
+brew trust --cask ygsgdbd/tap/typeswitch
+brew install --cask typeswitch
 ```
+
+这只会信任 `typeswitch` cask，不会信任整个 tap。Homebrew 会保存信任记录，因此通常只需执行一次 trust 命令。详情请参阅 Homebrew 官方的 [Tap Trust 文档](https://docs.brew.sh/Tap-Trust)。
+
+Homebrew 5.1.14 及更早版本没有 `brew trust`，也不需要执行该命令：
+
+```bash
+brew tap ygsgdbd/tap
+brew install --cask typeswitch
+```
+
+如果执行 `brew trust` 时出现 `Unknown command: trust`，请跳过该命令，或运行 `brew update` 升级 Homebrew。
 
 Homebrew 安装版使用以下命令更新：
 
 ```bash
 brew upgrade typeswitch
 ```
+
+#### Tap Trust 故障排查
+
+- 如果 Homebrew 提示 `Refusing to load cask ... from untrusted tap`，请执行 `brew trust --cask ygsgdbd/tap/typeswitch`，然后重新安装或升级。
+- 如果 `brew doctor` 报告 `ygsgdbd/tap` 未受信任，只需使用上述命令信任 TypeSwitch cask，不需要信任整个 tap。
+- 如果已有安装在 Homebrew 升级到 6.0.0 或更高版本后无法更新，请先信任该 cask，再重试 `brew upgrade typeswitch`。
+- 如果确实希望信任 tap 中所有当前及未来的 formula、cask 和 external command，可以使用 `brew trust ygsgdbd/tap`。该命令授权范围更大，不作为推荐方案。
 
 ### 手动安装
 


### PR DESCRIPTION
## 问题

TypeSwitch 的中英文 README 仍使用一条 fully-qualified Homebrew cask 安装命令，没有说明新版 Homebrew 对非官方 tap 的 Tap Trust 要求。使用 Homebrew 6.0.0 或更高版本的用户可能在安装、升级或运行 `brew doctor` 时遇到未信任 tap/cask 的提示，而旧版 Homebrew 用户又可能没有 `brew trust` 命令。

## 影响与根因

Homebrew 5.1.15 于 2026-06-03 首次提供 `brew trust`，但 5.x 仅在设置 `HOMEBREW_REQUIRE_TAP_TRUST=1` 时强制检查。从 Homebrew 6.0.0（2026-06-11）开始，非官方 tap 默认需要显式信任。原 README 没有覆盖这一版本差异，因此不能为不同 Homebrew 版本提供清晰、最小权限的安装指引。

## 修复

- 将 Homebrew 6.0.0+ 的安装流程更新为先 tap、仅信任 `ygsgdbd/tap/typeswitch` cask，再使用短名称安装。
- 为 Homebrew 5.1.14 及更早版本保留不包含 `brew trust` 的兼容流程，并说明遇到 `Unknown command: trust` 时可以跳过或升级 Homebrew。
- 增加安装、升级和 `brew doctor` 场景的 Tap Trust 故障排查。
- 说明 cask 级信任与整个 tap 信任的权限范围差异，并继续推荐最小权限方案。
- 同步更新英文 `README.md` 与简体中文 `README.zh-CN.md`。

## 验证

- `git diff --check HEAD^ HEAD`
- 断言两份 README 均包含 tap、cask trust、短名称安装及 5.1.15/6.0.0 版本说明。
- 确认旧的 `brew install ygsgdbd/tap/typeswitch --cask` 命令已从两份 README 移除。
- 此变更仅涉及文档，没有运行应用测试。
