### PR TITLE
[codex] Improve README highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <h1 align="center">TypeSwitch</h1>
 
-<p align="center">TypeSwitch is a macOS menu bar utility for switching input methods per app. Choose how each app should behave, set the rule for unconfigured apps, and let TypeSwitch switch to the right input method when the frontmost app changes.</p>
+<p align="center">TypeSwitch is a native macOS menu bar utility for switching input methods per app. Choose how each app should behave, set the rule for unconfigured apps, and let TypeSwitch switch to the right input method when the frontmost app changes.</p>
 
 <p align="center">
   <a href="https://swift.org"><img alt="Swift" src="https://img.shields.io/badge/Swift-5.9-orange.svg"></a>
@@ -27,20 +27,20 @@
 
 ![TypeSwitch dark appearance showing the main menu and current-app input method strategy](Documentation/Screenshots/en-dark.png#gh-dark-mode-only)
 
-## Features
+## Highlights
 
-- **Auto switch per app**: Switch input methods when the active app changes.
-- **Current App**: Configure the frontmost app directly at the top of the menu.
-- **Running rule groups**: Review `Running · Unconfigured` apps separately from `Running · Configured` apps.
-- **All Configured Apps**: Manage saved app rules from the menu bar.
-- **Default Rule for Unconfigured Apps**: Set the fallback behavior for apps without their own rule.
-- **Rule strategies**: Choose `Don't Switch`, `Last Switch`, or a `Specific Input Method`.
-- **Missing Apps cleanup**: Review rules for missing apps and clear stale settings.
-- **Switch statistics**: Track successful input method switches per app and clear the counts.
-- **Launch at Login**: Start TypeSwitch automatically after login, with a Login Items shortcut when macOS requires approval.
-- **Manual update checks**: Use `Check for Updates…` in the menu bar app for manual installs.
-- **Quick project access**: Open the GitHub repository from the menu.
-- **Keyboard shortcut**: Press `Command + Q` to quit TypeSwitch.
+- **Switch automatically for every app.** TypeSwitch watches the frontmost app and applies its saved input method rule as you move between apps.
+- **Choose the behavior that fits.** Use `Don't Switch`, `Last Switch`, or a `Specific Input Method`, with a separate default rule for apps you have not configured yet.
+- **Configure apps where you find them.** Set a rule for the current app, review running apps by configuration status, or manage every saved rule without leaving the menu bar.
+- **Keep rules and results tidy.** Find rules for missing apps, remove stale settings, review successful switch counts, and clear statistics when needed.
+- **Fit TypeSwitch into your workflow.** Launch it at login, check for updates through Sparkle, open the GitHub repository, or press `Command + Q` to quit.
+
+## Native and Lightweight
+
+- **Truly native.** TypeSwitch's app business code is written in Swift and built with SwiftUI and The Composable Architecture (TCA). It uses `MenuBarExtra` and `LSUIElement` instead of an Electron runtime or embedded WebView.
+- **Focused and lightweight.** TypeSwitch runs as a menu bar utility without shipping a browser engine or server component. App rules, the default rule, and switch statistics stay on your Mac.
+- **At home on macOS.** The interface follows Light and Dark Mode automatically. On macOS 26, native SwiftUI controls use the system-provided Liquid Glass appearance where appropriate, while macOS 14 and macOS 15 retain their native system styling. TypeSwitch does not simulate Liquid Glass with custom visual effects.
+- **Built for modern Macs.** The release workflow uses Xcode 26.2 and verifies every release as a Universal Binary for both Apple Silicon and Intel Macs.
 
 ## System Requirements
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 <h1 align="center">TypeSwitch</h1>
 
-<p align="center">TypeSwitch 是一款按 App 自动切换输入法的 macOS 菜单栏工具。为每个 App 选择输入法策略，设置未配置 App 的默认规则，并在前台 App 切换时自动切到对应输入法。</p>
+<p align="center">TypeSwitch 是一款按 App 自动切换输入法的原生 macOS 菜单栏工具。为每个 App 选择输入法策略，设置未配置 App 的默认规则，并在前台 App 切换时自动切到对应输入法。</p>
 
 <p align="center">
   <a href="https://swift.org"><img alt="Swift" src="https://img.shields.io/badge/Swift-5.9-orange.svg"></a>
@@ -27,20 +27,20 @@
 
 ![TypeSwitch 暗色模式主菜单和当前 App 输入法策略](Documentation/Screenshots/zh-Hans-dark.png#gh-dark-mode-only)
 
-## 功能特点
+## 功能亮点
 
-- **按 App 自动切换**：当前 App 变化时自动切换输入法。
-- **当前应用**：在菜单顶部直接配置当前前台 App。
-- **运行中规则分组**：将运行中且未配置的 App 与运行中且已配置的 App 分开查看。
-- **全部已配置 App**：在菜单栏中管理已保存的 App 规则。
-- **未配置 App 的默认规则**：设置没有单独规则的 App 应该如何处理。
-- **规则策略**：可选择“不自动切换”、“记住上次切换”或“指定输入法”。
-- **找不到的 App 清理**：查看不存在 App 的规则，并清理失效设置。
-- **切换统计**：按 App 记录成功切换次数，并可清零统计。
-- **登录时打开**：登录后自动运行，macOS 需要批准时可直接打开登录项设置。
-- **手动检查更新**：手动安装版可在菜单栏应用里使用“检查更新…”。
-- **项目入口**：从菜单直接打开 GitHub 仓库。
-- **快捷键**：按 `Command + Q` 退出 TypeSwitch。
+- **为每个 App 自动切换。** TypeSwitch 会监听当前前台 App，在你切换 App 时自动应用已保存的输入法规则。
+- **选择适合自己的切换方式。** 可使用“不自动切换”、“记住上次切换”或“指定输入法”，并为尚未单独配置的 App 设置独立的默认规则。
+- **随时配置遇到的 App。** 可直接设置当前 App，从按配置状态分组的运行中 App 里选择，或在菜单栏中管理全部已保存规则。
+- **保持规则与统计整洁。** 查找不存在 App 的规则、移除失效设置、查看成功切换次数，并按需清零统计。
+- **融入日常工作流程。** 支持登录时打开、通过 Sparkle 检查更新、访问 GitHub 仓库，以及使用 `Command + Q` 退出。
+
+## 原生与轻量
+
+- **真正原生。** TypeSwitch 的 App 业务代码使用 Swift 编写，并采用 SwiftUI 和 The Composable Architecture（TCA）架构。它基于 `MenuBarExtra` 与 `LSUIElement` 构建，不包含 Electron 运行时，也没有嵌入 WebView。
+- **专注且轻量。** TypeSwitch 作为菜单栏工具运行，无需附带浏览器引擎或服务端组件。App 规则、默认规则和切换统计都保存在你的 Mac 上。
+- **自然融入 macOS。** 界面会自动适配浅色与暗色模式。在 macOS 26 上，原生 SwiftUI 控件会在适用位置呈现系统提供的 Liquid Glass 外观；macOS 14 与 macOS 15 则保持各自的原生系统样式。TypeSwitch 不使用自定义视觉效果模拟 Liquid Glass。
+- **同时支持新旧 Mac。** Release workflow 使用 Xcode 26.2，并验证每个发布版本都是同时支持 Apple Silicon 与 Intel Mac 的 Universal Binary。
 
 ## 系统要求
 


### PR DESCRIPTION
## Issue

The README described TypeSwitch primarily as a list of individual menu actions. It did not clearly explain the user-facing value of the workflow or why the app is a native, focused macOS utility.

## User impact and root cause

Readers had to infer how the per-app rules, fallback behavior, app groups, cleanup tools, and switch statistics fit together. The documentation also omitted repository-backed details about the SwiftUI menu bar architecture and Universal Binary release process because the existing feature section focused on UI labels rather than product positioning.

## Changes

- Rewrites the English and Simplified Chinese feature sections as concise, value-oriented highlights.
- Adds matching native and lightweight sections covering Swift, SwiftUI, TCA, `MenuBarExtra`, `LSUIElement`, local storage, native macOS appearance, and the absence of Electron or an embedded WebView.
- Documents the Xcode 26.2 release build and Universal Binary verification for Apple Silicon and Intel Macs.
- Updates the introductory copy to identify TypeSwitch as a native macOS menu bar utility.

## Validation

- Verified the architecture claims against `Project.swift` and `TypeSwitch/Sources/App/TypeSwitchApp.swift`.
- Verified Xcode 26.2 and Universal Binary claims against `.github/workflows/release.yml`.
- Confirmed the English and Simplified Chinese section structure remains aligned.
- Ran `git diff HEAD^ --check` successfully.
- Confirmed the commit changes only `README.md` and `README.zh-CN.md`.
