### PR TITLE
[codex] Fix app rule migration recovery

### DIFF
--- a/TypeSwitch/Sources/App/AppFeature.swift
+++ b/TypeSwitch/Sources/App/AppFeature.swift
@@ -105,11 +105,10 @@ struct AppFeature {
     }
 
     enum ResponseAction: Equatable, Sendable {
-        case appRulesStorePrepared(AppRulesStoreMigration.PrepareResult)
         case frontmostApplicationLoaded(AppInfo?)
         case inputMethods([InputMethod])
         case launchAtLoginLoaded(LaunchAtLoginStatus)
-        case legacyRulesMigrated([String: AppRuleRecord])
+        case legacyRulesLoaded([String: AppRuleRecord])
         case programmaticSwitchFinished(bundleId: String, inputMethodId: String, didSwitch: Bool)
         case runningApps([AppInfo])
     }
@@ -154,7 +153,7 @@ struct AppFeature {
                 normalizeFallbackRule(in: &state)
                 return .merge(
                     .concatenate(
-                        prepareAppRulesStoreMigrationEffect(),
+                        migrateLegacyRulesEffect(),
                         .run { send in
                             await send(.response(.launchAtLoginLoaded(await launchAtLoginClient.status())))
                         },
@@ -189,14 +188,6 @@ struct AppFeature {
 
             case .view where state.isReadmeDemo:
                 return .none
-
-            case .response(.appRulesStorePrepared(let result)):
-                switch result {
-                case .currentStorePresent:
-                    return .none
-                case .noStoreFound:
-                    return migrateLegacyRulesEffect()
-                }
 
             case .response(.frontmostApplicationLoaded(let appInfo)):
                 state.currentFrontmostBundleId = appInfo?.bundleId
@@ -243,11 +234,19 @@ struct AppFeature {
                 state.launchAtLoginStatus = status
                 return .none
 
-            case .response(.legacyRulesMigrated(let migratedRules)):
-                state.$appRulesStore.withLock { store in
-                    store.rules.merge(migratedRules) { _, newValue in newValue }
+            case .response(.legacyRulesLoaded(let legacyRules)):
+                let mergedRules = AppRulesStoreMigration.merge(
+                    currentRules: state.appRules,
+                    legacyRules: legacyRules
+                )
+                guard mergedRules != state.appRules else {
+                    return markLegacyMigrationCompletedEffect()
                 }
-                return .none
+
+                state.$appRulesStore.withLock { store in
+                    store.rules = mergedRules
+                }
+                return saveLegacyMigrationEffect(store: state.$appRulesStore)
 
             case let .response(.programmaticSwitchFinished(bundleId, inputMethodId, didSwitch)):
                 if state.pendingProgrammaticSwitch == .init(bundleId: bundleId, inputMethodId: inputMethodId) {
@@ -429,20 +428,31 @@ struct AppFeature {
         }
     }
 
-    private func prepareAppRulesStoreMigrationEffect() -> Effect<Action> {
-        .run { send in
-            await send(.response(.appRulesStorePrepared(await appRulesStoreMigrationClient.prepareStore())))
-        }
-    }
-
     private func migrateLegacyRulesEffect() -> Effect<Action> {
         .run { send in
-            guard !(await legacyDefaultsMigrationClient.didCompleteMigration()) else {
+            guard await legacyDefaultsMigrationClient.completedVersion() < LegacyDefaultsMigration.currentVersion else {
                 return
             }
 
-            let migratedRules = await legacyDefaultsMigrationClient.migrateRules(now)
-            await send(.response(.legacyRulesMigrated(migratedRules)))
+            let legacyRules = await legacyDefaultsMigrationClient.loadRules(now)
+            await send(.response(.legacyRulesLoaded(legacyRules)))
+        }
+    }
+
+    private func saveLegacyMigrationEffect(store: Shared<AppRulesStore>) -> Effect<Action> {
+        .run { _ in
+            do {
+                try await appRulesStoreMigrationClient.save(store)
+                await legacyDefaultsMigrationClient.markCompleted(LegacyDefaultsMigration.currentVersion)
+            } catch {
+                print("⚠️ 规则存储迁移保存失败: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func markLegacyMigrationCompletedEffect() -> Effect<Action> {
+        .run { _ in
+            await legacyDefaultsMigrationClient.markCompleted(LegacyDefaultsMigration.currentVersion)
         }
     }
 

--- a/TypeSwitch/Sources/Migrations/AppRulesStoreMigration.swift
+++ b/TypeSwitch/Sources/Migrations/AppRulesStoreMigration.swift
@@ -1,50 +1,30 @@
 import ComposableArchitecture
-import Foundation
+import Sharing
 
-// Migration: v0 -> v1
-// Added: 2026-05-25
 enum AppRulesStoreMigration {
-    enum PrepareResult: Equatable, Sendable {
-        case currentStorePresent
-        case noStoreFound
-    }
-
-    static func prepareStore(
-        currentStoreURL: URL = .appRulesStoreURL,
-        fileManager: FileManager = .default
-    ) throws -> PrepareResult {
-        try fileManager.createDirectory(
-            at: currentStoreURL.deletingLastPathComponent(),
-            withIntermediateDirectories: true,
-            attributes: nil
-        )
-
-        if fileManager.fileExists(atPath: currentStoreURL.path) {
-            return .currentStorePresent
+    static func merge(
+        currentRules: [String: AppRuleRecord],
+        legacyRules: [String: AppRuleRecord]
+    ) -> [String: AppRuleRecord] {
+        currentRules.merging(legacyRules) { currentRule, legacyRule in
+            currentRule.strategy == .none ? legacyRule : currentRule
         }
-
-        return .noStoreFound
     }
 }
 
 struct AppRulesStoreMigrationClient {
-    var prepareStore: @Sendable () async -> AppRulesStoreMigration.PrepareResult
+    var save: @Sendable (_ store: Shared<AppRulesStore>) async throws -> Void
 }
 
 extension AppRulesStoreMigrationClient: DependencyKey {
     static let liveValue = Self(
-        prepareStore: {
-            do {
-                return try AppRulesStoreMigration.prepareStore()
-            } catch {
-                print("⚠️ 规则存储迁移失败: \(error.localizedDescription)")
-                return .noStoreFound
-            }
+        save: { store in
+            try await store.save()
         }
     )
 
     static let testValue = Self(
-        prepareStore: { .noStoreFound }
+        save: { _ in }
     )
 }
 

--- a/TypeSwitch/Sources/Migrations/LegacyDefaultsMigration.swift
+++ b/TypeSwitch/Sources/Migrations/LegacyDefaultsMigration.swift
@@ -1,23 +1,27 @@
 import ComposableArchitecture
 import Foundation
 
-// Migration: v0 -> v1
-// Added: 2026-05-25
+// Migration: legacy defaults -> app rules store
 enum LegacyDefaultsMigration {
+    static let currentVersion = 2
+    static let versionKey = "legacyAppRulesMigrationVersion"
+
+    static func completedVersion(in defaults: UserDefaults) -> Int {
+        defaults.integer(forKey: versionKey)
+    }
+
     static func makeRules(
         legacyMappings: [String: String],
         matchedApplications: [String: AppInfo],
         migrationDate: Date
     ) -> [String: AppRuleRecord] {
         legacyMappings.reduce(into: [String: AppRuleRecord]()) { result, entry in
-            guard let appInfo = matchedApplications[entry.key] else {
-                return
-            }
+            let appInfo = matchedApplications[entry.key]
 
             result[entry.key] = AppRuleRecord(
                 bundleId: entry.key,
-                lastKnownPath: appInfo.path,
-                lastKnownName: appInfo.name,
+                lastKnownPath: appInfo?.path,
+                lastKnownName: appInfo?.name ?? entry.key,
                 strategy: .fixed(inputMethodId: entry.value),
                 createdAt: migrationDate,
                 updatedAt: migrationDate
@@ -27,23 +31,20 @@ enum LegacyDefaultsMigration {
 }
 
 struct LegacyDefaultsMigrationClient {
-    var didCompleteMigration: @Sendable () async -> Bool
-    var migrateRules: @Sendable (_ migrationDate: Date) async -> [String: AppRuleRecord]
+    var completedVersion: @Sendable () async -> Int
+    var loadRules: @Sendable (_ migrationDate: Date) async -> [String: AppRuleRecord]
+    var markCompleted: @Sendable (_ version: Int) async -> Void
 }
 
 extension LegacyDefaultsMigrationClient: DependencyKey {
     static let liveValue = Self(
-        didCompleteMigration: {
-            UserDefaults.standard.bool(forKey: "didMigrateLegacyAppRules")
+        completedVersion: {
+            LegacyDefaultsMigration.completedVersion(in: .standard)
         },
-        migrateRules: { migrationDate in
+        loadRules: { migrationDate in
             let defaults = UserDefaults(suiteName: "group.top.ygsgdbd.TypeSwitch") ?? .standard
             let legacyMappings = defaults.dictionary(forKey: "appInputMethodSettings")?
                 .compactMapValues { $0 as? String } ?? [:]
-
-            defer {
-                UserDefaults.standard.set(true, forKey: "didMigrateLegacyAppRules")
-            }
 
             guard !legacyMappings.isEmpty else {
                 return [:]
@@ -55,12 +56,16 @@ extension LegacyDefaultsMigrationClient: DependencyKey {
                 matchedApplications: matchedApplications,
                 migrationDate: migrationDate
             )
+        },
+        markCompleted: { version in
+            UserDefaults.standard.set(version, forKey: LegacyDefaultsMigration.versionKey)
         }
     )
 
     static let testValue = Self(
-        didCompleteMigration: { true },
-        migrateRules: { _ in [:] }
+        completedVersion: { LegacyDefaultsMigration.currentVersion },
+        loadRules: { _ in [:] },
+        markCompleted: { _ in }
     )
 }
 

--- a/TypeSwitchTests/AppFeatureTests.swift
+++ b/TypeSwitchTests/AppFeatureTests.swift
@@ -1603,58 +1603,213 @@ final class AppFeatureTests: XCTestCase {
         XCTAssertEqual(state.totalSuccessfulSwitchCount, 12)
     }
 
-    func testLegacyMigrationMigratesOnlyMatchedRules() async {
+    func testLegacyRulesLoadedSavesBeforeMarkingMigrationCompleted() async {
         let migrationDate = Date(timeIntervalSince1970: 777)
         let migrationTracker = MigrationTracker()
-        let matchedApp = AppInfo(bundleId: "com.test.notes", name: "Notes", path: "/Applications/Notes.app")
+        let legacyRule = AppRuleRecord(
+            bundleId: "com.test.notes",
+            lastKnownPath: "/Applications/Notes.app",
+            lastKnownName: "Notes",
+            strategy: .fixed(inputMethodId: "ime.zh"),
+            createdAt: migrationDate,
+            updatedAt: migrationDate
+        )
 
-        let store = TestStore(initialState: AppFeature.State()) {
+        let store = TestStore(initialState: makeMigrationTestState()) {
+            AppFeature()
+        }
+        store.dependencies.appRulesStoreMigrationClient.save = { _ in
+            await migrationTracker.record(.save)
+        }
+        store.dependencies.legacyDefaultsMigrationClient.markCompleted = { version in
+            await migrationTracker.record(.markCompleted(version))
+        }
+
+        await store.send(.response(.legacyRulesLoaded([legacyRule.bundleId: legacyRule]))) {
+            $0.$appRulesStore.withLock {
+                $0.rules[legacyRule.bundleId] = legacyRule
+            }
+        }
+        await store.finish()
+
+        let events = await migrationTracker.events
+        XCTAssertEqual(events, [.save, .markCompleted(2)])
+    }
+
+    func testLegacyRulesLoadedDoesNotMarkMigrationCompletedWhenSaveFails() async {
+        let migrationTracker = MigrationTracker()
+        let legacyRule = AppRuleRecord(
+            bundleId: "com.test.notes",
+            lastKnownPath: "/Applications/Notes.app",
+            lastKnownName: "Notes",
+            strategy: .fixed(inputMethodId: "ime.zh"),
+            createdAt: Date(timeIntervalSince1970: 777),
+            updatedAt: Date(timeIntervalSince1970: 777)
+        )
+
+        let store = TestStore(initialState: makeMigrationTestState()) {
+            AppFeature()
+        }
+        store.dependencies.appRulesStoreMigrationClient.save = { _ in
+            await migrationTracker.record(.save)
+            throw TestError.failed
+        }
+        store.dependencies.legacyDefaultsMigrationClient.markCompleted = { version in
+            await migrationTracker.record(.markCompleted(version))
+        }
+
+        await store.send(.response(.legacyRulesLoaded([legacyRule.bundleId: legacyRule]))) {
+            $0.$appRulesStore.withLock {
+                $0.rules[legacyRule.bundleId] = legacyRule
+            }
+        }
+        await store.finish()
+
+        let events = await migrationTracker.events
+        XCTAssertEqual(events, [.save])
+    }
+
+    func testLegacyRulesLoadedWithoutLegacyMappingsKeepsCurrentRulesAndMarksCompleted() async {
+        let migrationTracker = MigrationTracker()
+        let currentRule = AppRuleRecord(
+            bundleId: "com.test.notes",
+            lastKnownPath: "/Applications/Notes.app",
+            lastKnownName: "Notes",
+            strategy: .ignored,
+            createdAt: Date(timeIntervalSince1970: 100),
+            updatedAt: Date(timeIntervalSince1970: 200)
+        )
+        var initialState = makeMigrationTestState()
+        initialState.$appRulesStore.withLock {
+            $0.rules[currentRule.bundleId] = currentRule
+        }
+
+        let store = TestStore(initialState: initialState) {
+            AppFeature()
+        }
+        store.dependencies.appRulesStoreMigrationClient.save = { _ in
+            await migrationTracker.record(.save)
+        }
+        store.dependencies.legacyDefaultsMigrationClient.markCompleted = { version in
+            await migrationTracker.record(.markCompleted(version))
+        }
+
+        await store.send(.response(.legacyRulesLoaded([:])))
+        await store.finish()
+
+        let events = await migrationTracker.events
+        XCTAssertEqual(events, [.markCompleted(2)])
+        XCTAssertEqual(store.state.appRules[currentRule.bundleId], currentRule)
+    }
+
+    func testTaskMigratesWithExistingEmptyStoreBeforeScanningRunningAppsAndDoesNotRepeatV2Migration() async throws {
+        let migrationDate = Date(timeIntervalSince1970: 777)
+        let migrationTracker = MigrationTracker()
+        let rootDirectory = FileManager.default.temporaryDirectory
+            .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+        let storeURL = rootDirectory.appending(path: AppStorageConfiguration.appRulesFilename)
+        try FileManager.default.createDirectory(
+            at: rootDirectory,
+            withIntermediateDirectories: true
+        )
+        try JSONEncoder().encode(AppRulesStore()).write(to: storeURL)
+        defer { try? FileManager.default.removeItem(at: rootDirectory) }
+
+        let legacyRule = AppRuleRecord(
+            bundleId: "com.test.notes",
+            lastKnownPath: "/Applications/Notes.app",
+            lastKnownName: "Notes",
+            strategy: .fixed(inputMethodId: "ime.zh"),
+            createdAt: migrationDate,
+            updatedAt: migrationDate
+        )
+
+        let initialState = AppFeature.State(
+            appRulesStore: Shared(
+                wrappedValue: AppRulesStore(),
+                .fileStorage(storeURL)
+            ),
+            appSwitchStatisticsStore: Shared(value: AppSwitchStatisticsStore()),
+            fallbackRuleStore: Shared(value: FallbackRuleStore())
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: storeURL.path))
+
+        let store = TestStore(initialState: initialState) {
             AppFeature()
         }
         store.dependencies.date = .constant(migrationDate)
-        store.dependencies.legacyDefaultsMigrationClient.didCompleteMigration = { false }
-        store.dependencies.legacyDefaultsMigrationClient.migrateRules = { receivedDate in
-            XCTAssertEqual(receivedDate, migrationDate)
-            await migrationTracker.markMigrated()
-            return [
-                "com.test.notes": AppRuleRecord(
-                    bundleId: "com.test.notes",
-                    lastKnownPath: matchedApp.path,
-                    lastKnownName: matchedApp.name,
-                    strategy: .fixed(inputMethodId: "ime.zh"),
-                    createdAt: migrationDate,
-                    updatedAt: migrationDate
-                ),
-            ]
+        store.dependencies.legacyDefaultsMigrationClient.completedVersion = {
+            await migrationTracker.completedVersion
         }
+        store.dependencies.legacyDefaultsMigrationClient.loadRules = { receivedDate in
+            await migrationTracker.record(.loadRules(receivedDate))
+            return [legacyRule.bundleId: legacyRule]
+        }
+        store.dependencies.legacyDefaultsMigrationClient.markCompleted = { version in
+            await migrationTracker.markCompleted(version)
+        }
+        store.dependencies.appRulesStoreMigrationClient.save = { _ in
+            await migrationTracker.record(.save)
+        }
+        store.dependencies.workspaceClient.runningApplications = {
+            await migrationTracker.record(.runningApplications)
+            return []
+        }
+        store.dependencies.workspaceClient.events = finishedStream
+        store.dependencies.inputMethodClient.availabilityChanges = finishedStream
+        store.dependencies.inputMethodClient.selectionChanges = finishedStream
 
-        await store.send(.response(.appRulesStorePrepared(.noStoreFound)))
-        await store.receive(.response(.legacyRulesMigrated([
-            "com.test.notes": AppRuleRecord(
-                bundleId: "com.test.notes",
-                lastKnownPath: matchedApp.path,
-                lastKnownName: matchedApp.name,
-                strategy: .fixed(inputMethodId: "ime.zh"),
-                createdAt: migrationDate,
-                updatedAt: migrationDate
-            ),
-        ]))) {
+        await store.send(.task)
+        await store.receive(.response(.legacyRulesLoaded([legacyRule.bundleId: legacyRule]))) {
             $0.$appRulesStore.withLock {
-                $0.rules["com.test.notes"] = AppRuleRecord(
-                    bundleId: "com.test.notes",
-                    lastKnownPath: matchedApp.path,
-                    lastKnownName: matchedApp.name,
-                    strategy: .fixed(inputMethodId: "ime.zh"),
-                    createdAt: migrationDate,
-                    updatedAt: migrationDate
-                )
+                $0.rules[legacyRule.bundleId] = legacyRule
             }
         }
+        await receiveStartupResponses(from: store)
+        await store.finish()
 
-        let didMigrate = await migrationTracker.didMigrate
-        XCTAssertTrue(didMigrate)
-        XCTAssertNil(store.state.appRules["com.test.missing"])
-        XCTAssertEqual(store.state.appRulesStore.v, MigrationVersion.current)
+        let migratedRule = store.state.appRules[legacyRule.bundleId]
+        let firstRunEvents = await migrationTracker.events
+        XCTAssertLessThan(
+            try XCTUnwrap(firstRunEvents.firstIndex(of: .loadRules(migrationDate))),
+            try XCTUnwrap(firstRunEvents.firstIndex(of: .runningApplications))
+        )
+        XCTAssertEqual(firstRunEvents.filter { $0 == .save }.count, 1)
+        XCTAssertEqual(firstRunEvents.filter { $0 == .markCompleted(2) }.count, 1)
+
+        await store.send(.task)
+        await receiveStartupResponses(from: store)
+        await store.finish()
+
+        let secondRunEvents = await migrationTracker.events
+        XCTAssertEqual(secondRunEvents.filter {
+            if case .loadRules = $0 { return true }
+            return false
+        }.count, 1)
+        XCTAssertEqual(secondRunEvents.filter { $0 == .save }.count, 1)
+        XCTAssertEqual(secondRunEvents.filter { $0 == .markCompleted(2) }.count, 1)
+        XCTAssertEqual(store.state.appRules[legacyRule.bundleId], migratedRule)
+    }
+
+    private func makeMigrationTestState() -> AppFeature.State {
+        AppFeature.State(
+            appRulesStore: Shared(value: AppRulesStore()),
+            appSwitchStatisticsStore: Shared(value: AppSwitchStatisticsStore()),
+            fallbackRuleStore: Shared(value: FallbackRuleStore())
+        )
+    }
+
+    private func receiveStartupResponses(from store: TestStoreOf<AppFeature>) async {
+        await store.receive(.response(.launchAtLoginLoaded(.disabled)))
+        await store.receive(.response(.frontmostApplicationLoaded(nil)))
+        await store.receive(.response(.inputMethods([])))
+        await store.receive(.response(.runningApps([])))
+    }
+
+    private func finishedStream<Element>() -> AsyncStream<Element> {
+        AsyncStream { continuation in
+            continuation.finish()
+        }
     }
 }
 
@@ -1671,9 +1826,22 @@ private enum TestError: Error {
 }
 
 private actor MigrationTracker {
-    private(set) var didMigrate = false
+    enum Event: Equatable {
+        case loadRules(Date)
+        case markCompleted(Int)
+        case runningApplications
+        case save
+    }
 
-    func markMigrated() {
-        didMigrate = true
+    private(set) var completedVersion = 0
+    private(set) var events: [Event] = []
+
+    func record(_ event: Event) {
+        events.append(event)
+    }
+
+    func markCompleted(_ version: Int) {
+        completedVersion = version
+        events.append(.markCompleted(version))
     }
 }

--- a/TypeSwitchTests/AppRulesStoreMigrationTests.swift
+++ b/TypeSwitchTests/AppRulesStoreMigrationTests.swift
@@ -153,57 +153,76 @@ final class AppRulesStoreMigrationTests: XCTestCase {
         ))
     }
 
-    func testPrepareStoreCreatesBundleDirectoryWhenStoreMissing() throws {
-        let fileManager = FileManager.default
-        let rootDirectory = fileManager.temporaryDirectory.appending(path: UUID().uuidString, directoryHint: .isDirectory)
-        try fileManager.createDirectory(at: rootDirectory, withIntermediateDirectories: true, attributes: nil)
-        defer { try? fileManager.removeItem(at: rootDirectory) }
+    func testMergeRestoresMissingAndNoneRulesWithoutOverwritingExplicitStrategies() {
+        let currentDate = Date(timeIntervalSince1970: 100)
+        let legacyDate = Date(timeIntervalSince1970: 200)
+        let currentRules = [
+            "none": makeRule(bundleId: "none", strategy: .none, date: currentDate),
+            "fixed": makeRule(bundleId: "fixed", strategy: .fixed(inputMethodId: "current.fixed"), date: currentDate),
+            "followLast": makeRule(
+                bundleId: "followLast",
+                strategy: .followLast(lastInputMethodId: "current.last"),
+                date: currentDate
+            ),
+            "ignored": makeRule(bundleId: "ignored", strategy: .ignored, date: currentDate),
+        ]
+        let legacyRules = [
+            "missing": makeRule(bundleId: "missing", strategy: .fixed(inputMethodId: "legacy.missing"), date: legacyDate),
+            "none": makeRule(bundleId: "none", strategy: .fixed(inputMethodId: "legacy.none"), date: legacyDate),
+            "fixed": makeRule(bundleId: "fixed", strategy: .fixed(inputMethodId: "legacy.fixed"), date: legacyDate),
+            "followLast": makeRule(bundleId: "followLast", strategy: .fixed(inputMethodId: "legacy.last"), date: legacyDate),
+            "ignored": makeRule(bundleId: "ignored", strategy: .fixed(inputMethodId: "legacy.ignored"), date: legacyDate),
+        ]
 
-        let currentStoreURL = URL.appRulesStoreFileURL(applicationSupportDirectory: rootDirectory)
-
-        let result = try AppRulesStoreMigration.prepareStore(
-            currentStoreURL: currentStoreURL,
-            fileManager: fileManager
+        let mergedRules = AppRulesStoreMigration.merge(
+            currentRules: currentRules,
+            legacyRules: legacyRules
         )
 
-        XCTAssertEqual(result, .noStoreFound)
-        XCTAssertFalse(fileManager.fileExists(atPath: currentStoreURL.path))
-        XCTAssertTrue(fileManager.fileExists(atPath: currentStoreURL.deletingLastPathComponent().path))
+        XCTAssertEqual(mergedRules["missing"], legacyRules["missing"])
+        XCTAssertEqual(mergedRules["none"], legacyRules["none"])
+        XCTAssertEqual(mergedRules["fixed"], currentRules["fixed"])
+        XCTAssertEqual(mergedRules["followLast"], currentRules["followLast"])
+        XCTAssertEqual(mergedRules["ignored"], currentRules["ignored"])
     }
 
-    func testPrepareStoreReportsCurrentStorePresentWhenFileExists() throws {
-        let fileManager = FileManager.default
-        let rootDirectory = fileManager.temporaryDirectory.appending(path: UUID().uuidString, directoryHint: .isDirectory)
-        try fileManager.createDirectory(at: rootDirectory, withIntermediateDirectories: true, attributes: nil)
-        defer { try? fileManager.removeItem(at: rootDirectory) }
+    func testMergeIsIdempotent() {
+        let currentDate = Date(timeIntervalSince1970: 100)
+        let legacyDate = Date(timeIntervalSince1970: 200)
+        let currentRules = [
+            "none": makeRule(bundleId: "none", strategy: .none, date: currentDate),
+            "fixed": makeRule(bundleId: "fixed", strategy: .fixed(inputMethodId: "current.fixed"), date: currentDate),
+        ]
+        let legacyRules = [
+            "none": makeRule(bundleId: "none", strategy: .fixed(inputMethodId: "legacy.none"), date: legacyDate),
+            "fixed": makeRule(bundleId: "fixed", strategy: .fixed(inputMethodId: "legacy.fixed"), date: legacyDate),
+        ]
 
-        let currentStoreURL = URL.appRulesStoreFileURL(applicationSupportDirectory: rootDirectory)
-        let currentStore = AppRulesStore(
-            rules: [
-                "current": AppRuleRecord(
-                    bundleId: "current",
-                    lastKnownPath: "/Applications/Current.app",
-                    lastKnownName: "Current",
-                    strategy: .none,
-                    createdAt: Date(timeIntervalSince1970: 50),
-                    updatedAt: Date(timeIntervalSince1970: 60)
-                ),
-            ]
+        let firstMerge = AppRulesStoreMigration.merge(
+            currentRules: currentRules,
+            legacyRules: legacyRules
         )
-        try fileManager.createDirectory(
-            at: currentStoreURL.deletingLastPathComponent(),
-            withIntermediateDirectories: true,
-            attributes: nil
-        )
-        let currentData = try JSONEncoder().encode(currentStore)
-        try currentData.write(to: currentStoreURL, options: [.atomic])
-
-        let result = try AppRulesStoreMigration.prepareStore(
-            currentStoreURL: currentStoreURL,
-            fileManager: fileManager
+        let secondMerge = AppRulesStoreMigration.merge(
+            currentRules: firstMerge,
+            legacyRules: legacyRules
         )
 
-        XCTAssertEqual(result, .currentStorePresent)
-        XCTAssertEqual(try Data(contentsOf: currentStoreURL), currentData)
+        XCTAssertEqual(secondMerge, firstMerge)
+        XCTAssertEqual(secondMerge["fixed"]?.updatedAt, currentDate)
+    }
+
+    private func makeRule(
+        bundleId: String,
+        strategy: InputMethodStrategy,
+        date: Date
+    ) -> AppRuleRecord {
+        AppRuleRecord(
+            bundleId: bundleId,
+            lastKnownPath: "/Applications/\(bundleId).app",
+            lastKnownName: bundleId,
+            strategy: strategy,
+            createdAt: date,
+            updatedAt: date
+        )
     }
 }

--- a/TypeSwitchTests/LegacyDefaultsMigrationTests.swift
+++ b/TypeSwitchTests/LegacyDefaultsMigrationTests.swift
@@ -3,7 +3,17 @@ import Foundation
 import XCTest
 
 final class LegacyDefaultsMigrationTests: XCTestCase {
-    func testMakeRulesMigratesOnlyMatchedApplications() {
+    func testV2CompletionIgnoresLegacyBooleanMarker() throws {
+        let suiteName = "LegacyDefaultsMigrationTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(true, forKey: "didMigrateLegacyAppRules")
+
+        XCTAssertEqual(LegacyDefaultsMigration.completedVersion(in: defaults), 0)
+    }
+
+    func testMakeRulesPreservesMatchedAndUnavailableApplications() {
         let migrationDate = Date(timeIntervalSince1970: 777)
         let matchedApplications = [
             "com.test.notes": AppInfo(
@@ -30,6 +40,14 @@ final class LegacyDefaultsMigrationTests: XCTestCase {
                     lastKnownPath: "/Applications/Notes.app",
                     lastKnownName: "Notes",
                     strategy: .fixed(inputMethodId: "ime.zh"),
+                    createdAt: migrationDate,
+                    updatedAt: migrationDate
+                ),
+                "com.test.missing": AppRuleRecord(
+                    bundleId: "com.test.missing",
+                    lastKnownPath: nil,
+                    lastKnownName: "com.test.missing",
+                    strategy: .fixed(inputMethodId: "ime.en"),
                     createdAt: migrationDate,
                     updatedAt: migrationDate
                 ),


### PR DESCRIPTION
## Problem

Some users could still have valid per-application input method mappings in the legacy app-group defaults while the current TypeSwitch menu showed no configured applications. The affected configuration was not actually deleted, but the one-time migration could be skipped before those mappings were copied into `app-rules.json`.

## Root cause and user impact

`@Shared.fileStorage` creates the current rules file as part of setting up its file subscription. Startup migration then used the existence of that file as the signal that migration was no longer required. The empty file could therefore win the startup race and suppress legacy migration. The legacy Boolean completion marker also prevented a corrected migration from running again for users who had already hit the bug.

This left affected users with `.none` placeholder rules generated from running applications while their original fixed input method mappings remained stranded in the legacy plist.

## Fix

This change introduces migration version 2 with `legacyAppRulesMigrationVersion` and removes file existence from the migration decision. Startup now loads legacy mappings before the regular frontmost and running application scans.

Every legacy mapping is converted into an app rule. Installed applications use their current name and path; unmatched bundle identifiers are retained as unavailable rules with the bundle identifier as the display name and no path.

The migration merges legacy data conservatively: missing and `.none` rules recover the legacy fixed strategy, while existing `.fixed`, `.followLast`, and `.ignored` choices remain authoritative. The merged shared store is explicitly saved, and version 2 is marked complete only after that save succeeds. A failed save leaves the version incomplete so the next launch retries. The original legacy defaults remain untouched.

## Validation

- `rtk just check`
- `git diff --check`
- Reproduced startup with an existing empty `app-rules.json` and verified migration still runs before the running-app scan
- Verified the old `didMigrateLegacyAppRules = true` marker does not suppress version 2
- Verified missing and `.none` rules are restored without overwriting `.fixed`, `.followLast`, or `.ignored` rules
- Verified unmatched applications remain as unavailable rules
- Verified a successful save occurs before marking version 2 complete
- Verified save failures do not write the completion marker
- Verified an empty legacy mapping leaves the current store unchanged
- Verified a second startup does not rerun migration or alter migrated timestamps
