### PR TITLE
[codex] Group menu sections

### DIFF
--- a/TypeSwitch/Sources/UI/Views/MenuBar/AppInfoView.swift
+++ b/TypeSwitch/Sources/UI/Views/MenuBar/AppInfoView.swift
@@ -9,34 +9,30 @@ struct AppInfoView: View {
 
     var body: some View {
         Group {
-            Section {
-                Button {
-                    updateMonitor.showUpdate(using: updaterController.updater)
-                } label: {
-                    Label(
-                        updateMonitor.menuTitle,
-                        systemImage: "arrow.triangle.2.circlepath"
-                    )
-                }
-                .disabled(!updateMonitor.isMenuActionEnabled)
+            Button {
+                updateMonitor.showUpdate(using: updaterController.updater)
+            } label: {
+                Label(
+                    updateMonitor.menuTitle,
+                    systemImage: "arrow.triangle.2.circlepath"
+                )
+            }
+            .disabled(!updateMonitor.isMenuActionEnabled)
 
-                Button {
-                    AppInfoService.openGitHubRepository()
-                } label: {
-                    Label(TypeSwitchStrings.Menu.githubRepository, systemImage: "link")
-                }
+            Button {
+                AppInfoService.openGitHubRepository()
+            } label: {
+                Label(TypeSwitchStrings.Menu.githubRepository, systemImage: "link")
             }
 
             Divider()
 
-            Section {
-                Button(role: .destructive) {
-                    NSApplication.shared.terminate(nil)
-                } label: {
-                    Label(TypeSwitchStrings.Menu.quit, systemImage: "power")
-                }
-                .keyboardShortcut("q", modifiers: .command)
+            Button(role: .destructive) {
+                NSApplication.shared.terminate(nil)
+            } label: {
+                Label(TypeSwitchStrings.Menu.quit, systemImage: "power")
             }
+            .keyboardShortcut("q", modifiers: .command)
         }
     }
 }

--- a/TypeSwitch/Sources/UI/Views/MenuBar/ConfiguredAppsView.swift
+++ b/TypeSwitch/Sources/UI/Views/MenuBar/ConfiguredAppsView.swift
@@ -7,44 +7,42 @@ struct ConfiguredAppsView: View {
 
     var body: some View {
         if !store.configuredApps.isEmpty {
-            Section {
-                Menu {
-                    if store.hasMissingInputMethodRules {
-                        Button(role: .destructive) {
-                            if MenuConfirmation.confirm(
-                                title: TypeSwitchStrings.InputMethod.ClearMissingConfirmation.title,
-                                message: TypeSwitchStrings.InputMethod.ClearMissingConfirmation.message,
-                                confirmButton: TypeSwitchStrings.InputMethod.ClearMissingConfirmation.confirm
-                            ) {
-                                store.send(.view(.removeMissingInputMethodRulesTapped))
-                            }
-                        } label: {
-                            Label(
-                                TypeSwitchStrings.InputMethod.clearMissingConfiguration,
-                                systemImage: "trash"
-                            )
+            Menu {
+                if store.hasMissingInputMethodRules {
+                    Button(role: .destructive) {
+                        if MenuConfirmation.confirm(
+                            title: TypeSwitchStrings.InputMethod.ClearMissingConfirmation.title,
+                            message: TypeSwitchStrings.InputMethod.ClearMissingConfirmation.message,
+                            confirmButton: TypeSwitchStrings.InputMethod.ClearMissingConfirmation.confirm
+                        ) {
+                            store.send(.view(.removeMissingInputMethodRulesTapped))
                         }
-
-                        Divider()
+                    } label: {
+                        Label(
+                            TypeSwitchStrings.InputMethod.clearMissingConfiguration,
+                            systemImage: "trash"
+                        )
                     }
 
-                    ForEach(store.configuredApps) { item in
-                        AppRowView(
-                            item: item,
-                            inputMethods: store.inputMethods,
-                            onIgnore: {
-                                store.send(.view(.ignoreAppTapped(item.appInfo)))
-                            }
-                        ) { strategy in
-                            store.send(.view(.setStrategy(bundleId: item.bundleId, strategy: strategy)))
-                        }
-                    }
-                } label: {
-                    Label(
-                        TypeSwitchStrings.Apps.Section.configuredCount(store.configuredApps.count),
-                        systemImage: "list.bullet.rectangle"
-                    )
+                    Divider()
                 }
+
+                ForEach(store.configuredApps) { item in
+                    AppRowView(
+                        item: item,
+                        inputMethods: store.inputMethods,
+                        onIgnore: {
+                            store.send(.view(.ignoreAppTapped(item.appInfo)))
+                        }
+                    ) { strategy in
+                        store.send(.view(.setStrategy(bundleId: item.bundleId, strategy: strategy)))
+                    }
+                }
+            } label: {
+                Label(
+                    TypeSwitchStrings.Apps.Section.configuredCount(store.configuredApps.count),
+                    systemImage: "list.bullet.rectangle"
+                )
             }
         }
     }

--- a/TypeSwitch/Sources/UI/Views/MenuBar/IgnoredAppsView.swift
+++ b/TypeSwitch/Sources/UI/Views/MenuBar/IgnoredAppsView.swift
@@ -6,40 +6,38 @@ struct IgnoredAppsView: View {
 
     var body: some View {
         if !store.ignoredAppsForMenu.isEmpty {
-            Section {
-                Menu {
-                    Section {
-                        ForEach(store.ignoredAppsForMenu) { app in
-                            Button {
-                                store.send(.view(.restoreIgnoredAppTapped(bundleId: app.bundleId)))
-                            } label: {
-                                Label {
-                                    Text(app.name)
-                                } icon: {
-                                    app.icon
-                                }
+            Menu {
+                Section {
+                    ForEach(store.ignoredAppsForMenu) { app in
+                        Button {
+                            store.send(.view(.restoreIgnoredAppTapped(bundleId: app.bundleId)))
+                        } label: {
+                            Label {
+                                Text(app.name)
+                            } icon: {
+                                app.icon
                             }
                         }
-                    } header: {
-                        Text(TypeSwitchStrings.Apps.Ignored.restoreHint)
                     }
+                } header: {
+                    Text(TypeSwitchStrings.Apps.Ignored.restoreHint)
+                }
 
-                    Divider()
+                Divider()
 
-                    Button {
-                        store.send(.view(.restoreAllIgnoredAppsTapped))
-                    } label: {
-                        Label(
-                            TypeSwitchStrings.Apps.Ignored.restoreAll,
-                            systemImage: "arrow.uturn.backward"
-                        )
-                    }
+                Button {
+                    store.send(.view(.restoreAllIgnoredAppsTapped))
                 } label: {
                     Label(
-                        TypeSwitchStrings.Apps.Ignored.menuTitle(store.ignoredAppsForMenu.count),
-                        systemImage: "eye.slash"
+                        TypeSwitchStrings.Apps.Ignored.restoreAll,
+                        systemImage: "arrow.uturn.backward"
                     )
                 }
+            } label: {
+                Label(
+                    TypeSwitchStrings.Apps.Ignored.menuTitle(store.ignoredAppsForMenu.count),
+                    systemImage: "eye.slash"
+                )
             }
         }
     }

--- a/TypeSwitch/Sources/UI/Views/MenuBar/MenuBarView.swift
+++ b/TypeSwitch/Sources/UI/Views/MenuBar/MenuBarView.swift
@@ -13,6 +13,14 @@ struct MenuBarView: View {
         Group {
             CurrentAppView(store: store)
             RunningAppsView(store: store)
+
+            if store.currentAppMenuItem != nil
+                || !store.runningUnconfiguredMenuItems.isEmpty
+                || !store.runningConfiguredMenuItems.isEmpty
+            {
+                Divider()
+            }
+
             ConfiguredAppsView(store: store)
             UnavailableAppsView(store: store)
             IgnoredAppsView(store: store)

--- a/TypeSwitch/Sources/UI/Views/MenuBar/SettingsView.swift
+++ b/TypeSwitch/Sources/UI/Views/MenuBar/SettingsView.swift
@@ -6,47 +6,45 @@ struct SettingsView: View {
     @Bindable var store: StoreOf<AppFeature>
 
     var body: some View {
-        Section {
-            Menu {
-                InputMethodStrategyMenuContent(
-                    context: .fallbackRule,
-                    strategy: store.fallbackStrategy,
-                    inputMethods: store.inputMethods,
-                    defaultOptionLabel: TypeSwitchStrings.InputMethod.fallbackDefaultOption,
-                    followLastOptionLabel: TypeSwitchStrings.InputMethod.followLastEmptyOption
-                ) { strategy in
-                    store.send(.view(.setFallbackStrategy(strategy)))
-                }
-            } label: {
-                Label(
-                    TypeSwitchStrings.Settings.Fallback.defaultInputMethod,
-                    systemImage: "keyboard"
-                )
-                if let selectedLabel = store.fallbackSelectedLabel {
-                    Text(selectedLabel)
-                        .foregroundStyle(store.fallbackHasMissingInputMethod ? .secondary : .primary)
-                }
+        Menu {
+            InputMethodStrategyMenuContent(
+                context: .fallbackRule,
+                strategy: store.fallbackStrategy,
+                inputMethods: store.inputMethods,
+                defaultOptionLabel: TypeSwitchStrings.InputMethod.fallbackDefaultOption,
+                followLastOptionLabel: TypeSwitchStrings.InputMethod.followLastEmptyOption
+            ) { strategy in
+                store.send(.view(.setFallbackStrategy(strategy)))
             }
-
-            Toggle(
-                TypeSwitchStrings.Settings.General.autoLaunch,
-                isOn: Binding(
-                    get: { store.launchAtLoginEnabled },
-                    set: { store.send(.view(.setLaunchAtLogin($0))) }
-                )
+        } label: {
+            Label(
+                TypeSwitchStrings.Settings.Fallback.defaultInputMethod,
+                systemImage: "keyboard"
             )
-            .toggleStyle(.checkbox)
+            if let selectedLabel = store.fallbackSelectedLabel {
+                Text(selectedLabel)
+                    .foregroundStyle(store.fallbackHasMissingInputMethod ? .secondary : .primary)
+            }
+        }
 
-            if store.launchAtLoginRequiresApproval {
-                Text(TypeSwitchStrings.Settings.General.autoLaunchRequiresApproval)
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
+        Toggle(
+            TypeSwitchStrings.Settings.General.autoLaunch,
+            isOn: Binding(
+                get: { store.launchAtLoginEnabled },
+                set: { store.send(.view(.setLaunchAtLogin($0))) }
+            )
+        )
+        .toggleStyle(.checkbox)
 
-                Button {
-                    LaunchAtLoginService.openSystemSettingsLoginItems()
-                } label: {
-                    Label(TypeSwitchStrings.Settings.General.openLoginItems, systemImage: "gear")
-                }
+        if store.launchAtLoginRequiresApproval {
+            Text(TypeSwitchStrings.Settings.General.autoLaunchRequiresApproval)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            Button {
+                LaunchAtLoginService.openSystemSettingsLoginItems()
+            } label: {
+                Label(TypeSwitchStrings.Settings.General.openLoginItems, systemImage: "gear")
             }
         }
     }

--- a/TypeSwitch/Sources/UI/Views/MenuBar/SwitchStatisticsView.swift
+++ b/TypeSwitch/Sources/UI/Views/MenuBar/SwitchStatisticsView.swift
@@ -5,43 +5,41 @@ struct SwitchStatisticsView: View {
     let store: StoreOf<AppFeature>
 
     var body: some View {
-        Section {
-            Menu {
-                if store.switchStatisticsItems.isEmpty {
-                    Text(TypeSwitchStrings.SwitchStatistics.empty)
-                        .foregroundStyle(.secondary)
-                } else {
-                    ForEach(store.switchStatisticsItems) { item in
-                        Button {} label: {
-                            if item.path != nil {
-                                AppInfo(bundleId: item.bundleId, name: item.name, path: item.path).icon
-                            }
-                            Text(item.name)
-                            Text(TypeSwitchStrings.SwitchStatistics.appCount(item.count))
+        Menu {
+            if store.switchStatisticsItems.isEmpty {
+                Text(TypeSwitchStrings.SwitchStatistics.empty)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(store.switchStatisticsItems) { item in
+                    Button {} label: {
+                        if item.path != nil {
+                            AppInfo(bundleId: item.bundleId, name: item.name, path: item.path).icon
                         }
-                        .disabled(true)
+                        Text(item.name)
+                        Text(TypeSwitchStrings.SwitchStatistics.appCount(item.count))
                     }
-
-                    Divider()
-
-                    Button(role: .destructive) {
-                        if MenuConfirmation.confirm(
-                            title: TypeSwitchStrings.SwitchStatistics.ClearConfirmation.title,
-                            message: TypeSwitchStrings.SwitchStatistics.ClearConfirmation.message,
-                            confirmButton: TypeSwitchStrings.SwitchStatistics.ClearConfirmation.confirm
-                        ) {
-                            store.send(.view(.clearSwitchStatisticsTapped))
-                        }
-                    } label: {
-                        Label(TypeSwitchStrings.SwitchStatistics.clear, systemImage: "trash")
-                    }
+                    .disabled(true)
                 }
-            } label: {
-                Label(
-                    TypeSwitchStrings.SwitchStatistics.menuTitle(store.totalSuccessfulSwitchCount),
-                    systemImage: "chart.bar"
-                )
+
+                Divider()
+
+                Button(role: .destructive) {
+                    if MenuConfirmation.confirm(
+                        title: TypeSwitchStrings.SwitchStatistics.ClearConfirmation.title,
+                        message: TypeSwitchStrings.SwitchStatistics.ClearConfirmation.message,
+                        confirmButton: TypeSwitchStrings.SwitchStatistics.ClearConfirmation.confirm
+                    ) {
+                        store.send(.view(.clearSwitchStatisticsTapped))
+                    }
+                } label: {
+                    Label(TypeSwitchStrings.SwitchStatistics.clear, systemImage: "trash")
+                }
             }
+        } label: {
+            Label(
+                TypeSwitchStrings.SwitchStatistics.menuTitle(store.totalSuccessfulSwitchCount),
+                systemImage: "chart.bar"
+            )
         }
     }
 }

--- a/TypeSwitch/Sources/UI/Views/MenuBar/UnavailableAppsView.swift
+++ b/TypeSwitch/Sources/UI/Views/MenuBar/UnavailableAppsView.swift
@@ -6,39 +6,37 @@ struct UnavailableAppsView: View {
 
     var body: some View {
         if !store.unavailableApps.isEmpty {
-            Section {
-                Menu {
-                    Button(role: .destructive) {
-                        if MenuConfirmation.confirm(
-                            title: TypeSwitchStrings.Apps.ClearUnavailableConfirmation.title,
-                            message: TypeSwitchStrings.Apps.ClearUnavailableConfirmation.message,
-                            confirmButton: TypeSwitchStrings.Apps.ClearUnavailableConfirmation.confirm
-                        ) {
-                            store.send(.view(.removeUnavailableRulesTapped))
-                        }
-                    } label: {
-                        Label(TypeSwitchStrings.Apps.clearUnavailable, systemImage: "trash")
-                    }
-
-                    Divider()
-
-                    ForEach(store.unavailableApps) { item in
-                        AppRowView(
-                            item: item,
-                            inputMethods: store.inputMethods,
-                            onIgnore: {
-                                store.send(.view(.ignoreAppTapped(item.appInfo)))
-                            }
-                        ) { strategy in
-                            store.send(.view(.setStrategy(bundleId: item.bundleId, strategy: strategy)))
-                        }
+            Menu {
+                Button(role: .destructive) {
+                    if MenuConfirmation.confirm(
+                        title: TypeSwitchStrings.Apps.ClearUnavailableConfirmation.title,
+                        message: TypeSwitchStrings.Apps.ClearUnavailableConfirmation.message,
+                        confirmButton: TypeSwitchStrings.Apps.ClearUnavailableConfirmation.confirm
+                    ) {
+                        store.send(.view(.removeUnavailableRulesTapped))
                     }
                 } label: {
-                    Label(
-                        TypeSwitchStrings.Apps.Section.unavailableCount(store.unavailableApps.count),
-                        systemImage: "exclamationmark.triangle"
-                    )
+                    Label(TypeSwitchStrings.Apps.clearUnavailable, systemImage: "trash")
                 }
+
+                Divider()
+
+                ForEach(store.unavailableApps) { item in
+                    AppRowView(
+                        item: item,
+                        inputMethods: store.inputMethods,
+                        onIgnore: {
+                            store.send(.view(.ignoreAppTapped(item.appInfo)))
+                        }
+                    ) { strategy in
+                        store.send(.view(.setStrategy(bundleId: item.bundleId, strategy: strategy)))
+                    }
+                }
+            } label: {
+                Label(
+                    TypeSwitchStrings.Apps.Section.unavailableCount(store.unavailableApps.count),
+                    systemImage: "exclamationmark.triangle"
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary

TypeSwitch currently wraps several single menu entries in separate SwiftUI `Section` containers. On macOS, each container renders its own separator, so the lower half of the menu appears fragmented even though the entries belong to a small number of related functional groups.

This change follows the grouping pattern already used by ListenBar: titled, dynamic application lists remain `Section`s, while ordinary actions are arranged continuously and explicit `Divider`s separate only distinct functional areas.

## User impact

The application management entries now read as one cohesive block instead of a stack of one-item groups. Settings, update/repository actions, and quit remain clearly separated. Menu labels, ordering, submenus, input method behavior, persistence, and actions are unchanged.

## Root cause

`ConfiguredAppsView`, `UnavailableAppsView`, `IgnoredAppsView`, `SwitchStatisticsView`, `SettingsView`, and `AppInfoView` each introduced container-level `Section`s. These sections were useful as code organization but unintentionally became visible separators in the native menu.

## Changes

- Remove unheaded wrapper sections from the application management, statistics, settings, and application information views.
- Add explicit dividers in `MenuBarView` between the application list, management, settings, and information areas.
- Keep the current, running unconfigured, and running configured application lists as titled sections.
- Avoid rendering a leading divider when no current or running application section is visible.
- Keep the ignored-app section inside its submenu, where the header remains meaningful.

## Validation

- `just lint`
- `just test` — 97 tests passed with 0 failures after rebasing onto the latest `main`
- `git diff --check`

The deterministic README screenshot generator was also attempted, but it correctly stopped because another TypeSwitch instance was running. No screenshot assets were modified.
