### PR TITLE
[codex] Preserve app rule migration metadata

### DIFF
--- a/TypeSwitch/Sources/Migrations/AppRulesStoreMigration.swift
+++ b/TypeSwitch/Sources/Migrations/AppRulesStoreMigration.swift
@@ -7,7 +7,18 @@ enum AppRulesStoreMigration {
         legacyRules: [String: AppRuleRecord]
     ) -> [String: AppRuleRecord] {
         currentRules.merging(legacyRules) { currentRule, legacyRule in
-            currentRule.strategy == .none ? legacyRule : currentRule
+            guard currentRule.strategy == .none else {
+                return currentRule
+            }
+
+            var recoveredRule = currentRule
+            if legacyRule.lastKnownPath != nil {
+                recoveredRule.lastKnownPath = legacyRule.lastKnownPath
+                recoveredRule.lastKnownName = legacyRule.lastKnownName
+            }
+            recoveredRule.strategy = legacyRule.strategy
+            recoveredRule.updatedAt = legacyRule.updatedAt
+            return recoveredRule
         }
     }
 }

--- a/TypeSwitchTests/AppFeatureTests.swift
+++ b/TypeSwitchTests/AppFeatureTests.swift
@@ -1604,18 +1604,39 @@ final class AppFeatureTests: XCTestCase {
     }
 
     func testLegacyRulesLoadedSavesBeforeMarkingMigrationCompleted() async {
+        let currentDate = Date(timeIntervalSince1970: 100)
         let migrationDate = Date(timeIntervalSince1970: 777)
         let migrationTracker = MigrationTracker()
-        let legacyRule = AppRuleRecord(
+        let currentRule = AppRuleRecord(
             bundleId: "com.test.notes",
             lastKnownPath: "/Applications/Notes.app",
             lastKnownName: "Notes",
+            strategy: .none,
+            createdAt: currentDate,
+            updatedAt: currentDate
+        )
+        let legacyRule = AppRuleRecord(
+            bundleId: currentRule.bundleId,
+            lastKnownPath: nil,
+            lastKnownName: currentRule.bundleId,
             strategy: .fixed(inputMethodId: "ime.zh"),
             createdAt: migrationDate,
             updatedAt: migrationDate
         )
+        let expectedRule = AppRuleRecord(
+            bundleId: currentRule.bundleId,
+            lastKnownPath: currentRule.lastKnownPath,
+            lastKnownName: currentRule.lastKnownName,
+            strategy: legacyRule.strategy,
+            createdAt: currentDate,
+            updatedAt: migrationDate
+        )
+        var initialState = makeMigrationTestState()
+        initialState.$appRulesStore.withLock {
+            $0.rules[currentRule.bundleId] = currentRule
+        }
 
-        let store = TestStore(initialState: makeMigrationTestState()) {
+        let store = TestStore(initialState: initialState) {
             AppFeature()
         }
         store.dependencies.appRulesStoreMigrationClient.save = { _ in
@@ -1627,7 +1648,7 @@ final class AppFeatureTests: XCTestCase {
 
         await store.send(.response(.legacyRulesLoaded([legacyRule.bundleId: legacyRule]))) {
             $0.$appRulesStore.withLock {
-                $0.rules[legacyRule.bundleId] = legacyRule
+                $0.rules[legacyRule.bundleId] = expectedRule
             }
         }
         await store.finish()

--- a/TypeSwitchTests/AppRulesStoreMigrationTests.swift
+++ b/TypeSwitchTests/AppRulesStoreMigrationTests.swift
@@ -153,11 +153,10 @@ final class AppRulesStoreMigrationTests: XCTestCase {
         ))
     }
 
-    func testMergeRestoresMissingAndNoneRulesWithoutOverwritingExplicitStrategies() {
+    func testMergeAddsMissingLegacyRulesWithoutOverwritingExplicitStrategies() {
         let currentDate = Date(timeIntervalSince1970: 100)
         let legacyDate = Date(timeIntervalSince1970: 200)
         let currentRules = [
-            "none": makeRule(bundleId: "none", strategy: .none, date: currentDate),
             "fixed": makeRule(bundleId: "fixed", strategy: .fixed(inputMethodId: "current.fixed"), date: currentDate),
             "followLast": makeRule(
                 bundleId: "followLast",
@@ -168,7 +167,6 @@ final class AppRulesStoreMigrationTests: XCTestCase {
         ]
         let legacyRules = [
             "missing": makeRule(bundleId: "missing", strategy: .fixed(inputMethodId: "legacy.missing"), date: legacyDate),
-            "none": makeRule(bundleId: "none", strategy: .fixed(inputMethodId: "legacy.none"), date: legacyDate),
             "fixed": makeRule(bundleId: "fixed", strategy: .fixed(inputMethodId: "legacy.fixed"), date: legacyDate),
             "followLast": makeRule(bundleId: "followLast", strategy: .fixed(inputMethodId: "legacy.last"), date: legacyDate),
             "ignored": makeRule(bundleId: "ignored", strategy: .fixed(inputMethodId: "legacy.ignored"), date: legacyDate),
@@ -180,10 +178,92 @@ final class AppRulesStoreMigrationTests: XCTestCase {
         )
 
         XCTAssertEqual(mergedRules["missing"], legacyRules["missing"])
-        XCTAssertEqual(mergedRules["none"], legacyRules["none"])
         XCTAssertEqual(mergedRules["fixed"], currentRules["fixed"])
         XCTAssertEqual(mergedRules["followLast"], currentRules["followLast"])
         XCTAssertEqual(mergedRules["ignored"], currentRules["ignored"])
+    }
+
+    func testMergeRestoresNoneRuleUsingMatchedLegacyMetadata() {
+        let currentDate = Date(timeIntervalSince1970: 100)
+        let legacyDate = Date(timeIntervalSince1970: 200)
+        let currentRule = AppRuleRecord(
+            bundleId: "com.test.editor",
+            lastKnownPath: "/Applications/Old Editor.app",
+            lastKnownName: "Old Editor",
+            strategy: .none,
+            createdAt: currentDate,
+            updatedAt: currentDate
+        )
+        let legacyRule = AppRuleRecord(
+            bundleId: currentRule.bundleId,
+            lastKnownPath: "/Applications/Editor.app",
+            lastKnownName: "Editor",
+            strategy: .fixed(inputMethodId: "legacy.fixed"),
+            createdAt: legacyDate,
+            updatedAt: legacyDate
+        )
+
+        let mergedRules = AppRulesStoreMigration.merge(
+            currentRules: [currentRule.bundleId: currentRule],
+            legacyRules: [legacyRule.bundleId: legacyRule]
+        )
+
+        XCTAssertEqual(
+            mergedRules[currentRule.bundleId],
+            AppRuleRecord(
+                bundleId: currentRule.bundleId,
+                lastKnownPath: legacyRule.lastKnownPath,
+                lastKnownName: legacyRule.lastKnownName,
+                strategy: legacyRule.strategy,
+                createdAt: currentDate,
+                updatedAt: legacyDate
+            )
+        )
+    }
+
+    func testMergeRestoresNoneRuleWithoutDiscardingCurrentMetadataWhenLegacyAppIsUnmatched() throws {
+        let currentDate = Date(timeIntervalSince1970: 100)
+        let legacyDate = Date(timeIntervalSince1970: 200)
+        let appURL = FileManager.default.temporaryDirectory
+            .appending(path: "Editor-\(UUID().uuidString).app", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: appURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: appURL) }
+
+        let currentRule = AppRuleRecord(
+            bundleId: "com.test.editor",
+            lastKnownPath: appURL.path,
+            lastKnownName: "Editor",
+            strategy: .none,
+            createdAt: currentDate,
+            updatedAt: currentDate
+        )
+        let legacyRule = AppRuleRecord(
+            bundleId: currentRule.bundleId,
+            lastKnownPath: nil,
+            lastKnownName: currentRule.bundleId,
+            strategy: .fixed(inputMethodId: "legacy.fixed"),
+            createdAt: legacyDate,
+            updatedAt: legacyDate
+        )
+
+        let mergedRules = AppRulesStoreMigration.merge(
+            currentRules: [currentRule.bundleId: currentRule],
+            legacyRules: [legacyRule.bundleId: legacyRule]
+        )
+        let mergedRule = try XCTUnwrap(mergedRules[currentRule.bundleId])
+
+        XCTAssertEqual(
+            mergedRule,
+            AppRuleRecord(
+                bundleId: currentRule.bundleId,
+                lastKnownPath: currentRule.lastKnownPath,
+                lastKnownName: currentRule.lastKnownName,
+                strategy: legacyRule.strategy,
+                createdAt: currentDate,
+                updatedAt: legacyDate
+            )
+        )
+        XCTAssertTrue(mergedRule.isAvailable)
     }
 
     func testMergeIsIdempotent() {


### PR DESCRIPTION
## Problem

PR #24 introduced migration version 2 to recover legacy per-application input method mappings. When a current `.none` placeholder already contained a valid application path and display name, the merge replaced the entire record with the legacy record.

If the targeted legacy application scan did not find that bundle identifier, the legacy record contained no path and used the bundle identifier as its display name. The replacement therefore discarded metadata that was already available in `app-rules.json`.

## User impact

An installed but non-running application could be moved into the unavailable applications section after migration. The recovered fixed input method strategy remained present, but the user could see the application as missing and remove its rule through the clear-unavailable action.

## Root cause

`AppRulesStoreMigration.merge` treated a `.none` collision by returning the complete legacy record. The migration only needed the legacy strategy to be authoritative; legacy application metadata is authoritative only when the migration scan actually matched the application.

## Fix

The merge now starts from the current `.none` record, restores the legacy strategy, and records the migration update timestamp. When the legacy scan supplies a path, its current path and display name are adopted. When the legacy path is absent, the existing path and display name are preserved. The original creation timestamp remains unchanged, while existing `.fixed`, `.followLast`, and `.ignored` rules remain fully authoritative.

Migration version 2 and the existing save-before-completion flow are unchanged because the migration has not yet shipped in a release.

## Validation

- `rtk just check`
- `rtk git diff --check`
- Added coverage for inserting missing legacy rules without overwriting explicit strategies
- Added coverage for refreshing metadata when the legacy scan succeeds
- Added coverage for preserving current metadata and availability when the legacy scan misses an installed application
- Verified merge idempotency
- Updated the reducer migration test to verify metadata preservation and save-before-completion ordering
