### PR TITLE
[codex] Attest release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 permissions:
   contents: write
   discussions: write
+  id-token: write
+  attestations: write
 
 jobs:
   build:
@@ -210,6 +212,11 @@ jobs:
             DerivedData/SparkleFeed
 
           cp DerivedData/SparkleFeed/appcast.xml appcast.xml
+
+      - name: Attest release artifact
+        uses: actions/attest@v4
+        with:
+          subject-path: TypeSwitch-macOS-universal.zip
       
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ brew trust --cask ygsgdbd/tap/typeswitch
 brew install --cask typeswitch
 ```
 
-This trusts only the `typeswitch` cask, not the entire tap. Homebrew stores the trust entry, so you normally need to run the trust command only once. See Homebrew's [Tap Trust documentation](https://docs.brew.sh/Tap-Trust) for details.
+This trusts only the third-party `typeswitch` cask, not the entire tap. Homebrew stores the trust entry, so you normally need to run the trust command only once. The cask also includes a custom `postflight` step that removes the macOS quarantine attribute from TypeSwitch after installation. TypeSwitch is still unsigned and not notarized, and `brew trust` is not an official Gatekeeper certification. See Homebrew's [Tap Trust documentation](https://docs.brew.sh/Tap-Trust) for details.
 
 Homebrew 5.1.14 and earlier do not have `brew trust` and do not require it:
 
@@ -88,8 +88,10 @@ brew upgrade typeswitch
 
 1. Download the latest build from [Releases](https://github.com/ygsgdbd/TypeSwitch/releases).
 2. Drag `TypeSwitch.app` to the Applications folder.
-3. Launch TypeSwitch and grant any system permissions macOS requests.
-4. Use `Check for Updates…` from the menu bar app to check GitHub Releases for future updates.
+3. In Applications, Control-click or right-click `TypeSwitch.app`, choose `Open`, then confirm that you want to open it.
+4. If macOS still blocks the app, open System Settings → Privacy & Security, find the TypeSwitch security message, and choose `Open Anyway`.
+5. Grant any system permissions macOS requests.
+6. Use `Check for Updates…` from the menu bar app to check GitHub Releases for future updates.
 
 ## 🧭 Usage
 
@@ -171,7 +173,13 @@ git tag v0.6.0
 git push origin v0.6.0
 ```
 
-The workflow validates the tag, runs tests, builds a universal macOS app, packages a zip, generates checksums, creates a signed Sparkle `appcast.xml`, publishes a GitHub Release, and updates the Homebrew cask.
+The workflow validates the tag, runs tests, builds a universal macOS app, packages a zip, publishes its SHA-256 checksum, signs the Sparkle `appcast.xml` with EdDSA, generates a GitHub Artifact Attestation for the release zip, publishes a GitHub Release, and updates the Homebrew cask.
+
+After downloading the release zip, verify its build provenance with GitHub CLI:
+
+```bash
+gh attestation verify TypeSwitch-macOS-universal.zip --repo ygsgdbd/TypeSwitch
+```
 
 ## 🙏 Acknowledgments
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -60,7 +60,7 @@ brew trust --cask ygsgdbd/tap/typeswitch
 brew install --cask typeswitch
 ```
 
-这只会信任 `typeswitch` cask，不会信任整个 tap。Homebrew 会保存信任记录，因此通常只需执行一次 trust 命令。详情请参阅 Homebrew 官方的 [Tap Trust 文档](https://docs.brew.sh/Tap-Trust)。
+这只会信任第三方 `typeswitch` cask，不会信任整个 tap。Homebrew 会保存信任记录，因此通常只需执行一次 trust 命令。该 cask 还包含自定义 `postflight` 步骤，会在安装后移除 TypeSwitch 的 macOS quarantine 属性。TypeSwitch 仍未签名、未经公证，`brew trust` 也不代表获得 Gatekeeper 官方认证。详情请参阅 Homebrew 官方的 [Tap Trust 文档](https://docs.brew.sh/Tap-Trust)。
 
 Homebrew 5.1.14 及更早版本没有 `brew trust`，也不需要执行该命令：
 
@@ -88,8 +88,10 @@ brew upgrade typeswitch
 
 1. 从 [Releases](https://github.com/ygsgdbd/TypeSwitch/releases) 下载最新构建。
 2. 将 `TypeSwitch.app` 拖入“应用程序”文件夹。
-3. 启动 TypeSwitch，并授予 macOS 请求的系统权限。
-4. 后续可在菜单栏应用中使用“检查更新…”从 GitHub Releases 检查更新。
+3. 在“应用程序”中按住 Control 点击或右键点击 `TypeSwitch.app`，选择“打开”，然后确认打开。
+4. 如果 macOS 仍然阻止运行，请打开“系统设置”→“隐私与安全性”，找到 TypeSwitch 的安全提示并选择“仍要打开”。
+5. 授予 macOS 请求的系统权限。
+6. 后续可在菜单栏应用中使用“检查更新…”从 GitHub Releases 检查更新。
 
 ## 🧭 使用说明
 
@@ -171,7 +173,13 @@ git tag v0.6.0
 git push origin v0.6.0
 ```
 
-发布 workflow 会校验标签、运行测试、构建 universal macOS app、打包 zip、生成 checksums、创建已签名的 Sparkle `appcast.xml`、发布 GitHub Release，并更新 Homebrew cask。
+发布 workflow 会校验标签、运行测试、构建 universal macOS app、打包 zip、发布 SHA-256 checksum、使用 EdDSA 签名 Sparkle `appcast.xml`、为发布 zip 生成 GitHub Artifact Attestation、发布 GitHub Release，并更新 Homebrew cask。
+
+下载发布 zip 后，可使用 GitHub CLI 验证其构建来源：
+
+```bash
+gh attestation verify TypeSwitch-macOS-universal.zip --repo ygsgdbd/TypeSwitch
+```
 
 ## 🙏 致谢
 


### PR DESCRIPTION
## Summary

- add GitHub Artifact Attestation for the final macOS release zip
- keep the existing SHA-256 checksum, Sparkle EdDSA signature, and release asset set unchanged
- document the Homebrew cask's quarantine handling and its security boundary
- update English and Chinese manual-install instructions and provenance verification guidance

## User impact

Homebrew installs can launch directly through the custom cask behavior, while the README remains explicit that TypeSwitch is unsigned and not notarized. Release downloads also gain GitHub build provenance that users can verify with `gh attestation verify`.

## Validation

- `rtk just check` passed
- workflow YAML parsing passed
- `actionlint` passed after ignoring two existing unrelated findings: `SC2129` in checksum generation and the existing `softprops/action-gh-release@v1`
- `git diff --check` passed
