### PR TITLE
[codex] unify build and release pipeline

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.2'
+          xcode-version: '26.5'
 
       - name: Install tools
         run: brew install just tuist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,18 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing vX.Y.Z tag; dispatch with the same tag ref via CLI or API
+        required: true
+        type: string
 
 permissions:
   contents: write
-  discussions: write
   id-token: write
   attestations: write
+  artifact-metadata: write
 
 jobs:
   build:
@@ -24,20 +30,97 @@ jobs:
 
       - name: Validate release tag
         id: release_tag
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
         run: |
-          if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error title=Invalid release tag::Production releases must use vX.Y.Z, for example v0.4.0. Got ${GITHUB_REF_NAME}."
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error title=Invalid release tag::Production releases must use vX.Y.Z, for example v0.10.0. Got ${RELEASE_TAG}."
             exit 1
           fi
 
-          VERSION="${GITHUB_REF_NAME#v}"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "$(git cat-file -t "refs/tags/${RELEASE_TAG}" 2>/dev/null || true)" != "tag" ]]; then
+            echo "::error title=Invalid release tag::Tag ${RELEASE_TAG} must be an annotated tag."
+            exit 1
+          fi
+
+          if ! TAG_COMMIT=$(git rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}" 2>/dev/null); then
+            echo "::error title=Invalid release tag::Tag ${RELEASE_TAG} does not resolve to a commit."
+            exit 1
+          fi
+
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            if [[ "$GITHUB_REF_TYPE" != "tag" || "$GITHUB_REF_NAME" != "$RELEASE_TAG" ]]; then
+              echo "::error title=Invalid manual release ref::Manual releases must be dispatched from tag ${RELEASE_TAG}. Run: gh workflow run release.yml --ref ${RELEASE_TAG} -f release_tag=${RELEASE_TAG}"
+              exit 1
+            fi
+          elif [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            if [[ "$GITHUB_REF_TYPE" != "tag" || "$GITHUB_REF_NAME" != "$RELEASE_TAG" ]]; then
+              echo "::error title=Invalid tag push ref::Expected tag ref ${RELEASE_TAG}, got ${GITHUB_REF_TYPE} ${GITHUB_REF_NAME}."
+              exit 1
+            fi
+          else
+            echo "::error title=Unsupported release event::Expected push or workflow_dispatch, got ${GITHUB_EVENT_NAME}."
+            exit 1
+          fi
+
+          if [[ "$GITHUB_SHA" != "$TAG_COMMIT" ]]; then
+            echo "::error title=Release source mismatch::Event commit ${GITHUB_SHA} does not match tag ${RELEASE_TAG} commit ${TAG_COMMIT}."
+            exit 1
+          fi
+
+          if ! git rev-parse --verify "origin/main^{commit}" >/dev/null 2>&1; then
+            echo "::error title=Missing main branch::Unable to resolve origin/main from the release checkout."
+            exit 1
+          fi
+
+          if ! git merge-base --is-ancestor "$TAG_COMMIT" origin/main; then
+            echo "::error title=Release tag not on main::Tag ${RELEASE_TAG} commit ${TAG_COMMIT} is not contained in origin/main."
+            exit 1
+          fi
+
+          VERSION="${RELEASE_TAG#v}"
+          {
+            echo "tag=$RELEASE_TAG"
+            echo "version=$VERSION"
+            echo "commit=$TAG_COMMIT"
+          } >> "$GITHUB_OUTPUT"
+          echo "Release tag: $RELEASE_TAG"
           echo "Release version: $VERSION"
-      
+          echo "Release commit: $TAG_COMMIT"
+
+      - name: Checkout validated release commit
+        env:
+          RELEASE_COMMIT: ${{ steps.release_tag.outputs.commit }}
+        run: |
+          git checkout --detach "$RELEASE_COMMIT"
+          HEAD_COMMIT=$(git rev-parse HEAD)
+
+          if [[ "$HEAD_COMMIT" != "$RELEASE_COMMIT" ]]; then
+            echo "::error title=Release checkout mismatch::Checked out ${HEAD_COMMIT}, expected ${RELEASE_COMMIT}."
+            exit 1
+          fi
+
+          echo "Checked out release commit: $HEAD_COMMIT"
+
+      - name: Check publishing secrets
+        env:
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [[ -z "$SPARKLE_ED_PRIVATE_KEY" ]]; then
+            echo "::error title=Missing Sparkle signing key::Set the SPARKLE_ED_PRIVATE_KEY repository secret before publishing a release."
+            exit 1
+          fi
+
+          if [[ -z "$HOMEBREW_TAP_TOKEN" ]]; then
+            echo "::error title=Missing Homebrew tap token::Set the HOMEBREW_TAP_TOKEN repository secret before publishing a release."
+            exit 1
+          fi
+
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.2'
+          xcode-version: '26.5'
       
       - name: Install Tuist
         run: |
@@ -102,8 +185,10 @@ jobs:
           ditto -c -k --sequesterRsrc --keepParent TypeSwitch.app ../../TypeSwitch-macOS-universal.zip
 
       - name: Prepare release notes
+        env:
+          RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}
         run: |
-          if ! awk -v version="${GITHUB_REF_NAME}" '
+          if ! awk -v version="${RELEASE_TAG}" '
             $0 == "## " version {
               found = 1
               next
@@ -138,11 +223,11 @@ jobs:
               }
             }
           ' CHANGELOG.md > release-notes.md; then
-            echo "::error title=Missing release notes::CHANGELOG.md must contain a non-empty ## ${GITHUB_REF_NAME} section."
+            echo "::error title=Missing release notes::CHANGELOG.md must contain a non-empty ## ${RELEASE_TAG} section."
             exit 1
           fi
 
-          echo "Release notes for ${GITHUB_REF_NAME}:"
+          echo "Release notes for ${RELEASE_TAG}:"
           cat release-notes.md
 
       - name: Render Sparkle release notes HTML
@@ -166,13 +251,15 @@ jobs:
       
       - name: Generate Checksums
         run: |
-          echo "### SHA-256 Checksums" > checksums.txt
-          echo "\`\`\`" >> checksums.txt
-          shasum -a 256 TypeSwitch-macOS-universal.zip >> checksums.txt
-          echo "\`\`\`" >> checksums.txt
+          {
+            echo "### SHA-256 Checksums"
+            echo '```'
+            shasum -a 256 TypeSwitch-macOS-universal.zip
+            echo '```'
+          } > checksums.txt
 
           {
-            echo "## TypeSwitch ${{ github.ref_name }}"
+            echo "## TypeSwitch ${{ steps.release_tag.outputs.tag }}"
             echo ""
             cat release-notes.md
             echo ""
@@ -186,26 +273,31 @@ jobs:
 
       - name: Download Sparkle tools
         run: |
-          curl -fsSL -o Sparkle-2.9.4.tar.xz https://github.com/sparkle-project/Sparkle/releases/download/2.9.4/Sparkle-2.9.4.tar.xz
-          mkdir -p sparkle-tools
-          tar -xf Sparkle-2.9.4.tar.xz -C sparkle-tools --strip-components=1
+          SPARKLE_ARCHIVE="Sparkle-2.9.4.tar.xz"
+          EXPECTED_SHA256="ce89daf967db1e1893ed3ebd67575ed82d3902563e3191ca92aaec9164fbdef9"
+          curl -fsSL -o "$SPARKLE_ARCHIVE" https://github.com/sparkle-project/Sparkle/releases/download/2.9.4/Sparkle-2.9.4.tar.xz
 
-      - name: Generate Sparkle appcast
-        env:
-          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
-        run: |
-          if [[ -z "$SPARKLE_ED_PRIVATE_KEY" ]]; then
-            echo "::error title=Missing Sparkle signing key::Set the SPARKLE_ED_PRIVATE_KEY repository secret before publishing a release."
+          ACTUAL_SHA256=$(shasum -a 256 "$SPARKLE_ARCHIVE" | awk '{print $1}')
+          if [[ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]]; then
+            echo "::error title=Sparkle checksum mismatch::Expected ${EXPECTED_SHA256}, got ${ACTUAL_SHA256}."
             exit 1
           fi
 
+          mkdir -p sparkle-tools
+          tar -xf "$SPARKLE_ARCHIVE" -C sparkle-tools --strip-components=1
+
+      - name: Generate Sparkle appcast
+        env:
+          RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+        run: |
           mkdir -p DerivedData/SparkleFeed
           cp TypeSwitch-macOS-universal.zip DerivedData/SparkleFeed/
           cp release-notes.html DerivedData/SparkleFeed/TypeSwitch-macOS-universal.html
 
           printf '%s' "$SPARKLE_ED_PRIVATE_KEY" | ./sparkle-tools/bin/generate_appcast \
             --ed-key-file - \
-            --download-url-prefix "https://github.com/ygsgdbd/TypeSwitch/releases/download/${GITHUB_REF_NAME}/" \
+            --download-url-prefix "https://github.com/ygsgdbd/TypeSwitch/releases/download/${RELEASE_TAG}/" \
             --link "https://github.com/ygsgdbd/TypeSwitch" \
             --embed-release-notes \
             --maximum-versions 1 \
@@ -219,7 +311,7 @@ jobs:
           subject-path: TypeSwitch-macOS-universal.zip
       
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             TypeSwitch-macOS-universal.zip
@@ -229,6 +321,7 @@ jobs:
           draft: false
           prerelease: false
           generate_release_notes: true
+          tag_name: ${{ steps.release_tag.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -242,19 +335,35 @@ jobs:
       - name: Update Homebrew cask
         env:
           ASSET_NAME: TypeSwitch-macOS-universal.zip
+          RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}
           VERSION: ${{ steps.release_tag.outputs.version }}
         run: |
           SHA256=$(shasum -a 256 "$ASSET_NAME" | awk '{print $1}')
           CASK_PATH="homebrew-tap/Casks/typeswitch.rb"
 
-          export VERSION SHA256 CASK_PATH
+          export RELEASE_TAG VERSION SHA256 CASK_PATH
           ruby <<'RUBY'
           path = ENV.fetch("CASK_PATH")
+          release_tag = ENV.fetch("RELEASE_TAG")
+          version = ENV.fetch("VERSION")
+          sha256 = ENV.fetch("SHA256")
+
+          abort "Homebrew cask does not exist: #{path}" unless File.file?(path)
+
           content = File.read(path)
-          content.gsub!(/version ".*"/, "version \"#{ENV.fetch("VERSION")}\"")
-          content.gsub!(/sha256 ".*"/, "sha256 \"#{ENV.fetch("SHA256")}\"")
-          content.gsub!(%r{url ".*"}, "url \"https://github.com/ygsgdbd/TypeSwitch/releases/download/#{ENV.fetch("GITHUB_REF_NAME")}/#{ENV.fetch("ASSET_NAME")}\"")
-          content.gsub!(/depends_on macos: ".*"/, "depends_on macos: \">= :sonoma\"")
+          replacements = {
+            /^  version ".*"$/ => "  version \"#{version}\"",
+            /^  sha256 ".*"$/ => "  sha256 \"#{sha256}\"",
+            /^  url ".*"$/ => "  url \"https://github.com/ygsgdbd/TypeSwitch/releases/download/#{release_tag}/TypeSwitch-macOS-universal.zip\"",
+          }
+
+          replacements.each do |pattern, replacement|
+            matches = content.scan(pattern).length
+            abort "Expected exactly one #{pattern.inspect} entry in #{path}, found #{matches}" unless matches == 1
+
+            content.sub!(pattern, replacement)
+          end
+
           File.write(path, content)
           RUBY
 
@@ -268,5 +377,5 @@ jobs:
             exit 0
           fi
 
-          git commit -m "Update TypeSwitch cask to ${GITHUB_REF_NAME}"
+          git commit -m "Update TypeSwitch cask to ${RELEASE_TAG}"
           git push

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 - **Truly native.** TypeSwitch's app business code is written in Swift and built with SwiftUI and The Composable Architecture (TCA). It uses `MenuBarExtra` and `LSUIElement` instead of an Electron runtime or embedded WebView.
 - **Focused and lightweight.** TypeSwitch runs as a menu bar utility without shipping a browser engine or server component. App rules, the default rule, and switch statistics stay on your Mac.
 - **At home on macOS.** The interface follows Light and Dark Mode automatically. On macOS 26, native SwiftUI controls use the system-provided Liquid Glass appearance where appropriate, while macOS 14 and macOS 15 retain their native system styling. TypeSwitch does not simulate Liquid Glass with custom visual effects.
-- **Built for modern Macs.** The release workflow uses Xcode 26.2 and verifies every release as a Universal Binary for both Apple Silicon and Intel Macs.
+- **Built for modern Macs.** The release workflow uses Xcode 26.5 and verifies every release as a Universal Binary for both Apple Silicon and Intel Macs.
 
 ## 💻 System Requirements
 
@@ -127,18 +127,21 @@ This project uses:
 
 ### Requirements
 
-- Xcode 15.0+
+- Xcode 26.5+
 - Swift 5.9+
 - macOS 14.0+
+- [just](https://github.com/casey/just)
 - [Tuist](https://github.com/tuist/tuist)
+- [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) (version pinned in `.swiftformat-version`)
 - [ImageMagick](https://imagemagick.org/)
 - RTK (`rtk`, required by the screenshot generation script)
 
 ### Build Steps
 
-Install Tuist:
+Install the required development tools:
 
 ```bash
+brew install just swiftformat
 brew tap tuist/tuist
 brew install --formula tuist
 ```
@@ -152,10 +155,10 @@ tuist generate
 open TypeSwitch.xcworkspace
 ```
 
-Run tests:
+Run the same formatting and test checks required by pull requests:
 
 ```bash
-tuist test
+just check
 ```
 
 To regenerate the deterministic, privacy-safe README screenshots, grant your terminal or Codex Screen Recording and Accessibility permissions, quit other running TypeSwitch instances, and run:
@@ -166,14 +169,20 @@ To regenerate the deterministic, privacy-safe README screenshots, grant your ter
 
 ### Release Workflow
 
-Production releases are built by GitHub Actions when a `vX.Y.Z` tag is pushed:
+Production releases are built by GitHub Actions when a strict, annotated `vX.Y.Z` tag on `main` is pushed:
 
 ```bash
-git tag v0.6.0
-git push origin v0.6.0
+git tag -a v0.10.0 -m "TypeSwitch v0.10.0"
+git push origin v0.10.0
 ```
 
 The workflow validates the tag, runs tests, builds a universal macOS app, packages a zip, publishes its SHA-256 checksum, signs the Sparkle `appcast.xml` with EdDSA, generates a GitHub Artifact Attestation for the release zip, publishes a GitHub Release, and updates the Homebrew cask.
+
+To rerun an existing release, dispatch the workflow from that same tag ref. A branch or a different tag ref is rejected:
+
+```bash
+gh workflow run release.yml --ref v0.10.0 -f release_tag=v0.10.0
+```
 
 After downloading the release zip, verify its build provenance with GitHub CLI:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -40,7 +40,7 @@
 - **真正原生。** TypeSwitch 的 App 业务代码使用 Swift 编写，并采用 SwiftUI 和 The Composable Architecture（TCA）架构。它基于 `MenuBarExtra` 与 `LSUIElement` 构建，不包含 Electron 运行时，也没有嵌入 WebView。
 - **专注且轻量。** TypeSwitch 作为菜单栏工具运行，无需附带浏览器引擎或服务端组件。App 规则、默认规则和切换统计都保存在你的 Mac 上。
 - **自然融入 macOS。** 界面会自动适配浅色与暗色模式。在 macOS 26 上，原生 SwiftUI 控件会在适用位置呈现系统提供的 Liquid Glass 外观；macOS 14 与 macOS 15 则保持各自的原生系统样式。TypeSwitch 不使用自定义视觉效果模拟 Liquid Glass。
-- **同时支持新旧 Mac。** Release workflow 使用 Xcode 26.2，并验证每个发布版本都是同时支持 Apple Silicon 与 Intel Mac 的 Universal Binary。
+- **同时支持新旧 Mac。** Release workflow 使用 Xcode 26.5，并验证每个发布版本都是同时支持 Apple Silicon 与 Intel Mac 的 Universal Binary。
 
 ## 💻 系统要求
 
@@ -127,18 +127,21 @@ brew upgrade typeswitch
 
 ### 环境要求
 
-- Xcode 15.0+
+- Xcode 26.5+
 - Swift 5.9+
 - macOS 14.0+
+- [just](https://github.com/casey/just)
 - [Tuist](https://github.com/tuist/tuist)
+- [SwiftFormat](https://github.com/nicklockwood/SwiftFormat)（版本由 `.swiftformat-version` 固定）
 - [ImageMagick](https://imagemagick.org/)
 - RTK（`rtk`，截图生成脚本需要）
 
 ### 构建步骤
 
-安装 Tuist：
+安装所需开发工具：
 
 ```bash
+brew install just swiftformat
 brew tap tuist/tuist
 brew install --formula tuist
 ```
@@ -152,10 +155,10 @@ tuist generate
 open TypeSwitch.xcworkspace
 ```
 
-运行测试：
+运行与 Pull Request 相同的格式检查和测试：
 
 ```bash
-tuist test
+just check
 ```
 
 如需重新生成内容固定且不包含用户真实规则、输入法或统计信息的 README 截图，请先为终端或 Codex 授予“屏幕与系统音频录制”和“辅助功能”权限，退出其他正在运行的 TypeSwitch 实例，然后执行：
@@ -166,14 +169,20 @@ tuist test
 
 ### 发布流程
 
-推送 `vX.Y.Z` 标签后，GitHub Actions 会构建正式版本：
+推送位于 `main`、格式严格为 `vX.Y.Z` 的 annotated tag 后，GitHub Actions 会构建正式版本：
 
 ```bash
-git tag v0.6.0
-git push origin v0.6.0
+git tag -a v0.10.0 -m "TypeSwitch v0.10.0"
+git push origin v0.10.0
 ```
 
 发布 workflow 会校验标签、运行测试、构建 universal macOS app、打包 zip、发布 SHA-256 checksum、使用 EdDSA 签名 Sparkle `appcast.xml`、为发布 zip 生成 GitHub Artifact Attestation、发布 GitHub Release，并更新 Homebrew cask。
+
+如需重跑已有发布，必须从同一个 tag ref 手动触发；从分支或其他 tag ref 触发会被拒绝：
+
+```bash
+gh workflow run release.yml --ref v0.10.0 -f release_tag=v0.10.0
+```
 
 下载发布 zip 后，可使用 GitHub CLI 验证其构建来源：
 


### PR DESCRIPTION
## Summary

- align PR and release jobs on Xcode 26.5
- require annotated release tags on `main`, validate event/tag/commit identity, and support same-tag manual reruns
- preflight publishing secrets and verify the Sparkle tools checksum
- use Artifact Attestation permissions and `softprops/action-gh-release@v2`
- harden Homebrew version, SHA, and URL replacement
- synchronize bilingual build and release documentation

## Why

Align TypeSwitch with the shared release provenance and integrity contract while preserving its entitlements, ZIP artifact, tests, and unsigned distribution model.

## Checks

- `rtk just check`
- `rtk actionlint .github/workflows/*.yml`
- workflow YAML parsing and Homebrew Ruby syntax
- annotated `v0.9.0` tag and `origin/main` ancestry verification
- `rtk git diff --check`
