### PR TITLE
[codex] fix documented review issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,12 @@ jobs:
             echo "commit=$TAG_COMMIT"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Ensure GitHub Release does not already exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}
+        run: script/ensure_release_absent.sh "$GITHUB_REPOSITORY" "$RELEASE_TAG"
+
       - name: Check Sparkle signing key
         env:
           SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - 修复恢复已忽略 App 时丢失原输入法策略的问题，并为菜单栏图标补充当前 App 状态的 VoiceOver 描述。
 - 修复输入法目录加载期间激活 App 时可能漏掉自动切换的问题；目录加载完成后仅补偿处理此前被跳过的当前 App。
 - 修复手动切换到正确输入法后仍保留失败警告的问题，并让 VoiceOver 在输入法异常时优先播报警告状态。
-- 加固发布链路：阻止版本回退和跨版本并发，提前验证 Homebrew 写权限，并校验 Sparkle 签名与 App 内置公钥一致。
+- 加固发布链路：阻止版本回退和跨版本并发，并校验 Sparkle 签名与 App 内置公钥一致。
 
 ### 🇺🇸 English
 
@@ -28,7 +28,7 @@
 - Fixed restored ignored apps losing their previous input method strategy, and added VoiceOver descriptions for the current app state in the menu bar icon.
 - Fixed automatic switching being skipped when an app activates while the input method catalog is loading; TypeSwitch now retries only the current app whose activation was deferred.
 - Fixed stale failure warnings after manually selecting the correct input method, and made VoiceOver announce input method warnings before the current app state.
-- Hardened releases against version rollback and cross-version races, added an early Homebrew write-access check, and verified Sparkle signatures against the public key embedded in the app.
+- Hardened releases against version rollback and cross-version races, and verified Sparkle signatures against the public key embedded in the app.
 
 ## v0.9.0
 

--- a/Documentation/CodeReview-2026-08-17.md
+++ b/Documentation/CodeReview-2026-08-17.md
@@ -1,44 +1,44 @@
 # 未提交改动审查记录（2026-08-17）
 
-本记录覆盖输入法切换补偿、支持诊断与发布链路相关改动。2026-08-19 已处理发布降级 P1；以下 P2/P3 仅记录，尚未修复。
+本记录覆盖输入法切换补偿、支持诊断与发布链路相关改动。2026-08-19 已处理发布降级 P1 及以下 P2/P3。
 
-## 待处理问题
+## 已处理问题（2026-08-19）
 
 ### P2：诊断信息缺少 Locale
 
 `SupportDiagnostics` 已使用 `Bundle.main.preferredLocalizations.first` 报告 App 界面语言，但没有同时记录 `Locale.current.identifier`。区域格式、排序或界面语言与地区不一致的问题仍缺少必要上下文。
 
-建议分别输出 `App Language` 和 `Locale`，并增加二者不同及 App language 缺失时的测试。
+处理：诊断报告分别输出 `App Language` 和 `Locale`，其中 Locale 来自 `Locale.current.identifier`；测试覆盖二者不同、App language 缺失及 Locale 缺失占位。
 
 ### P2：同 tag rerun 可能让 Release 正文与资产不一致
 
 `.github/workflows/release.yml` 使用时间戳 build 重新构建产物，同时配置 `overwrite_files: false`。如果同一 tag 的首次运行已上传资产后失败，rerun 会生成新的 ZIP、checksum 和 `release-body.md`；action 会跳过同名资产，但仍可能更新 Release 正文，造成正文 checksum 指向新 ZIP、实际下载仍是旧 ZIP。
 
-建议后续在构建前检测该 tag 的 GitHub Release 是否已存在并直接失败，避免对不可变 Release 做同 tag 重建。
+处理：新增发布前检查，仅 GitHub API 返回 404 时继续；Release 已存在、鉴权、限流、服务或网络错误均在构建前失败，`overwrite_files: false` 继续作为第二道保护。
 
 ### P2：手动切回失败目标会重新显示旧警告
 
 `AppFeature.swift` 的确认选择流程在更新 `followLast` 前判断是否清理失败记录。场景“自动切换 A 失败 → 手动切到 B → 手动切回 A”中，旧失败会再次成为当前目标并重新显示。
 
-建议先更新 `followLast` 再清理，或在确认选择匹配失败目标时直接清理，并增加对应回归测试。
+处理：同 App 的手动选择匹配失败目标时直接清理旧失败记录，不再依赖更新前的 current target；回归测试覆盖“自动切换 A 失败 → 手动切到 B → 手动切回 A”。
 
 ### P2：VoiceOver 警告覆盖当前 App 状态
 
 `AppFeature+MenuState.swift` 在存在输入法异常时只返回通用 warning，丢失原有的 configured、unconfigured 或 ignored 状态，与“先播报警告，再播报当前 App 状态”的发布说明不一致。
 
-建议组合“警告 + 当前状态”，并覆盖异常下 configured/unconfigured 状态及播报顺序。
+处理：有前台 App 时使用完整本地化文案组合“警告 + configured/unconfigured/ignored”，无前台 App 时保留通用 warning；测试覆盖三种状态和警告优先顺序。
 
 ### P3：Homebrew updater 测试未断言首次更新结果
 
 `script/test_release_scripts.sh` 的 updater fixture 已将 version、SHA 和 URL 设为旧值，但第一次运行后直接把任意结果保存为预期内容，只验证第二次运行幂等。如果 updater 以后不再替换 SHA 或 URL，测试仍会通过。
 
-建议让 version、sha256 和 url 三个字段全部使用旧值，并逐项断言更新后的目标内容和第二次运行的幂等性。
+处理：首次运行 updater 后分别断言 version、sha256 和 url 的目标值，再验证第二次运行幂等及版本降级拒绝。
 
 ### P3：发布说明仍描述已删除的 Homebrew 权限预检
 
 `CHANGELOG.md` 仍宣称发布前会验证 Homebrew token 写权限，但当前简化流程明确以 GitHub Release 为发布事实来源，Homebrew 允许短暂延迟，token 只在 Homebrew checkout 中使用。本记录此前的同类“已处理”陈述也已不再成立。
 
-建议后续同步修订 `CHANGELOG.md`，保留“阻止版本回退”的描述，删除 Homebrew 权限预检已完成的表述。
+处理：同步修订 `CHANGELOG.md` 中英文说明，保留版本回退、跨版本并发和 Sparkle 公钥校验，删除 Homebrew 权限预检表述。
 
 ## 已处理（2026-08-19）
 
@@ -48,7 +48,7 @@
 
 ## 已验证
 
-- 重新生成 Tuist 工程后的完整 macOS XCTest：128 tests，0 failures。
+- 重新生成 Tuist 工程后的完整 macOS XCTest：131 tests，0 failures。
 - `script/test_release_scripts.sh`：通过。
 - Shell、Ruby、workflow YAML 和 `git diff --check`：通过。
 - SwiftFormat 0.62.1：0 个文件需要格式化。

--- a/TypeSwitch/Resources/Base.lproj/Localizable.strings
+++ b/TypeSwitch/Resources/Base.lproj/Localizable.strings
@@ -5,6 +5,9 @@
 "menu.accessibility_unconfigured" = "TypeSwitch，当前 App 未配置";
 "menu.accessibility_ignored" = "TypeSwitch，当前 App 已忽略";
 "menu.accessibility_warning" = "TypeSwitch，输入法状态警告";
+"menu.accessibility_warning_configured" = "TypeSwitch，输入法状态警告，当前 App 已配置";
+"menu.accessibility_warning_unconfigured" = "TypeSwitch，输入法状态警告，当前 App 未配置";
+"menu.accessibility_warning_ignored" = "TypeSwitch，输入法状态警告，当前 App 已忽略";
 
 // 通用
 "common.cancel" = "取消";

--- a/TypeSwitch/Resources/en.lproj/Localizable.strings
+++ b/TypeSwitch/Resources/en.lproj/Localizable.strings
@@ -5,6 +5,9 @@
 "menu.accessibility_unconfigured" = "TypeSwitch, current app unconfigured";
 "menu.accessibility_ignored" = "TypeSwitch, current app ignored";
 "menu.accessibility_warning" = "TypeSwitch, input method warning";
+"menu.accessibility_warning_configured" = "TypeSwitch, input method warning, current app configured";
+"menu.accessibility_warning_unconfigured" = "TypeSwitch, input method warning, current app unconfigured";
+"menu.accessibility_warning_ignored" = "TypeSwitch, input method warning, current app ignored";
 
 // Common
 "common.cancel" = "Cancel";

--- a/TypeSwitch/Resources/zh-Hans.lproj/Localizable.strings
+++ b/TypeSwitch/Resources/zh-Hans.lproj/Localizable.strings
@@ -5,6 +5,9 @@
 "menu.accessibility_unconfigured" = "TypeSwitch，当前 App 未配置";
 "menu.accessibility_ignored" = "TypeSwitch，当前 App 已忽略";
 "menu.accessibility_warning" = "TypeSwitch，输入法状态警告";
+"menu.accessibility_warning_configured" = "TypeSwitch，输入法状态警告，当前 App 已配置";
+"menu.accessibility_warning_unconfigured" = "TypeSwitch，输入法状态警告，当前 App 未配置";
+"menu.accessibility_warning_ignored" = "TypeSwitch，输入法状态警告，当前 App 已忽略";
 
 // 通用
 "common.cancel" = "取消";

--- a/TypeSwitch/Resources/zh-Hant.lproj/Localizable.strings
+++ b/TypeSwitch/Resources/zh-Hant.lproj/Localizable.strings
@@ -5,6 +5,9 @@
 "menu.accessibility_unconfigured" = "TypeSwitch，目前 App 未設定";
 "menu.accessibility_ignored" = "TypeSwitch，目前 App 已忽略";
 "menu.accessibility_warning" = "TypeSwitch，輸入法狀態警告";
+"menu.accessibility_warning_configured" = "TypeSwitch，輸入法狀態警告，目前 App 已設定";
+"menu.accessibility_warning_unconfigured" = "TypeSwitch，輸入法狀態警告，目前 App 未設定";
+"menu.accessibility_warning_ignored" = "TypeSwitch，輸入法狀態警告，目前 App 已忽略";
 
 // 通用
 "common.cancel" = "取消";

--- a/TypeSwitch/Sources/App/AppFeature+MenuState.swift
+++ b/TypeSwitch/Sources/App/AppFeature+MenuState.swift
@@ -42,7 +42,18 @@ extension AppFeature.State {
 
     var menuBarAccessibilityLabel: String {
         if inputMethodDiagnostic != nil {
-            return TypeSwitchStrings.Menu.accessibilityWarning
+            guard let currentFrontmostBundleId else {
+                return TypeSwitchStrings.Menu.accessibilityWarning
+            }
+
+            switch strategy(for: currentFrontmostBundleId) {
+            case .none:
+                return TypeSwitchStrings.Menu.accessibilityWarningUnconfigured
+            case .fixed, .followLast:
+                return TypeSwitchStrings.Menu.accessibilityWarningConfigured
+            case .ignored:
+                return TypeSwitchStrings.Menu.accessibilityWarningIgnored
+            }
         }
 
         guard let currentFrontmostBundleId else {

--- a/TypeSwitch/Sources/App/AppFeature.swift
+++ b/TypeSwitch/Sources/App/AppFeature.swift
@@ -301,8 +301,7 @@ struct AppFeature {
                 if let lastSwitchAttempt = state.lastSwitchAttempt,
                    lastSwitchAttempt.bundleId == bundleId,
                    lastSwitchAttempt.inputMethodId == inputMethodId,
-                   case .failed = lastSwitchAttempt.outcome,
-                   state.isCurrentTarget(lastSwitchAttempt)
+                   case .failed = lastSwitchAttempt.outcome
                 {
                     state.lastSwitchAttempt = nil
                 }

--- a/TypeSwitch/Sources/Services/AppManagement/SupportDiagnostics.swift
+++ b/TypeSwitch/Sources/Services/AppManagement/SupportDiagnostics.swift
@@ -7,6 +7,7 @@ struct SupportDiagnostics: Equatable {
     let operatingSystemVersion: String
     let architecture: String
     let appLanguage: String
+    let localeIdentifier: String
     let diagnosticCategory: String?
     let errorDescription: String?
 
@@ -16,6 +17,7 @@ struct SupportDiagnostics: Equatable {
         operatingSystemVersion: String,
         architecture: String,
         appLanguage: String?,
+        localeIdentifier: String?,
         diagnosticCategory: String? = nil,
         errorDescription: String? = nil
     ) {
@@ -24,6 +26,7 @@ struct SupportDiagnostics: Equatable {
         self.operatingSystemVersion = operatingSystemVersion
         self.architecture = architecture
         self.appLanguage = Self.valueOrPlaceholder(appLanguage)
+        self.localeIdentifier = Self.valueOrPlaceholder(localeIdentifier)
         self.diagnosticCategory = diagnosticCategory
         self.errorDescription = errorDescription
     }
@@ -42,6 +45,7 @@ struct SupportDiagnostics: Equatable {
             operatingSystemVersion: ProcessInfo.processInfo.operatingSystemVersionString,
             architecture: currentArchitecture,
             appLanguage: bundle.preferredLocalizations.first,
+            localeIdentifier: Locale.current.identifier,
             diagnosticCategory: diagnosticCategory,
             errorDescription: errorDescription
         )
@@ -54,6 +58,7 @@ struct SupportDiagnostics: Equatable {
             "macOS: \(operatingSystemVersion)",
             "Architecture: \(architecture)",
             "App Language: \(appLanguage)",
+            "Locale: \(localeIdentifier)",
         ]
         if let diagnosticCategory {
             lines.append("Diagnostic category: \(diagnosticCategory)")

--- a/TypeSwitchTests/AppFeatureTests.swift
+++ b/TypeSwitchTests/AppFeatureTests.swift
@@ -2731,44 +2731,56 @@ final class AppFeatureTests: XCTestCase {
         XCTAssertEqual(state.menuBarAccessibilityLabel, TypeSwitchStrings.Menu.accessibilityIgnored)
     }
 
-    func testMenuBarAccessibilityLabelPrioritizesInputMethodDiagnostics() {
-        let bundleId = "com.test.chat"
-        let failedAttempt = AppFeature.State.LastSwitchAttempt(
-            appName: "Chat",
-            bundleId: bundleId,
-            inputMethodId: "ime.zh",
-            inputMethodName: "Pinyin",
-            outcome: .failed(.failedToSwitchInputMethod("ime.zh")),
-            ruleSource: .app,
-            timestamp: Date(timeIntervalSince1970: 10)
-        )
-
+    func testMenuBarAccessibilityLabelUsesWarningWithoutFrontmostApp() {
         var catalogEmptyState = AppFeature.State()
         catalogEmptyState.inputMethodCatalogStatus = .ready
 
         var catalogFailedState = AppFeature.State()
         catalogFailedState.inputMethodCatalogStatus = .failed(.failedToFetchInputMethods)
 
-        var switchFailedState = AppFeature.State()
-        switchFailedState.currentFrontmostBundleId = bundleId
-        switchFailedState.inputMethodCatalogStatus = .ready
-        switchFailedState.inputMethods = [InputMethod(id: "ime.zh", name: "Pinyin")]
-        switchFailedState.lastSwitchAttempt = failedAttempt
-        switchFailedState.$appRulesStore.withLock {
+        for state in [catalogEmptyState, catalogFailedState] {
+            XCTAssertNotNil(state.inputMethodDiagnostic)
+            XCTAssertEqual(state.menuBarAccessibilityLabel, TypeSwitchStrings.Menu.accessibilityWarning)
+        }
+    }
+
+    func testMenuBarAccessibilityLabelCombinesWarningWithFrontmostAppStatus() {
+        let bundleId = "com.test.chat"
+        var state = AppFeature.State(
+            currentFrontmostBundleId: bundleId,
+            inputMethodCatalogStatus: .failed(.failedToFetchInputMethods)
+        )
+        state.$appRulesStore.withLock {
             $0.rules[bundleId] = AppRuleRecord(
                 bundleId: bundleId,
                 lastKnownPath: "/Applications/Chat.app",
                 lastKnownName: "Chat",
-                strategy: .fixed(inputMethodId: "ime.zh"),
+                strategy: .none,
                 createdAt: Date(timeIntervalSince1970: 10),
                 updatedAt: Date(timeIntervalSince1970: 10)
             )
         }
 
-        for state in [catalogEmptyState, catalogFailedState, switchFailedState] {
-            XCTAssertNotNil(state.inputMethodDiagnostic)
-            XCTAssertEqual(state.menuBarAccessibilityLabel, TypeSwitchStrings.Menu.accessibilityWarning)
+        XCTAssertEqual(
+            state.menuBarAccessibilityLabel,
+            TypeSwitchStrings.Menu.accessibilityWarningUnconfigured
+        )
+
+        state.$appRulesStore.withLock {
+            $0.rules[bundleId]?.strategy = .fixed(inputMethodId: "ime.zh")
         }
+        XCTAssertEqual(
+            state.menuBarAccessibilityLabel,
+            TypeSwitchStrings.Menu.accessibilityWarningConfigured
+        )
+
+        state.$appRulesStore.withLock {
+            $0.rules[bundleId]?.strategy = .ignored
+        }
+        XCTAssertEqual(
+            state.menuBarAccessibilityLabel,
+            TypeSwitchStrings.Menu.accessibilityWarningIgnored
+        )
     }
 
     func testFollowLastWithoutRecordShowsEmptyMenuOption() {
@@ -2950,6 +2962,79 @@ final class AppFeatureTests: XCTestCase {
         }
 
         XCTAssertNil(store.state.inputMethodDiagnostic)
+        XCTAssertEqual(store.state.appSwitchStatisticsStore.counts[bundleId], 2)
+    }
+
+    func testManualSelectionOfStaleFailedFollowLastTargetClearsDiagnosticWithoutIncrementingStatistics() async {
+        let bundleId = "com.test.chat"
+        let failedInputMethod = "ime.zh"
+        let otherInputMethod = "ime.jp"
+        let updateDate = Date(timeIntervalSince1970: 888)
+
+        var initialState = AppFeature.State()
+        initialState.currentFrontmostBundleId = bundleId
+        initialState.inputMethodCatalogStatus = .ready
+        initialState.inputMethods = [
+            InputMethod(id: failedInputMethod, name: "Pinyin"),
+            InputMethod(id: otherInputMethod, name: "Japanese"),
+        ]
+        initialState.lastSwitchAttempt = .init(
+            appName: "Chat",
+            bundleId: bundleId,
+            inputMethodId: failedInputMethod,
+            inputMethodName: "Pinyin",
+            outcome: .failed(.failedToSwitchInputMethod(failedInputMethod)),
+            ruleSource: .app,
+            timestamp: Date(timeIntervalSince1970: 10)
+        )
+        initialState.$appRulesStore.withLock {
+            $0.rules[bundleId] = AppRuleRecord(
+                bundleId: bundleId,
+                lastKnownPath: "/Applications/Chat.app",
+                lastKnownName: "Chat",
+                strategy: .followLast(lastInputMethodId: failedInputMethod),
+                createdAt: Date(timeIntervalSince1970: 10),
+                updatedAt: Date(timeIntervalSince1970: 10)
+            )
+        }
+        initialState.$appSwitchStatisticsStore.withLock {
+            $0.counts[bundleId] = 2
+        }
+
+        let store = TestStore(initialState: initialState) {
+            AppFeature()
+        }
+        store.dependencies.date = .constant(updateDate)
+
+        XCTAssertEqual(store.state.inputMethodDiagnostic?.kind, .switchFailed)
+
+        await store.send(.system(.inputMethodSelectedChanged(otherInputMethod))) {
+            $0.$appRulesStore.withLock {
+                guard var rule = $0.rules[bundleId] else { return }
+                rule.strategy = .followLast(lastInputMethodId: otherInputMethod)
+                rule.updatedAt = updateDate
+                $0.rules[bundleId] = rule
+            }
+        }
+
+        XCTAssertNil(store.state.inputMethodDiagnostic)
+        XCTAssertNotNil(store.state.lastSwitchAttempt)
+
+        await store.send(.system(.inputMethodSelectedChanged(failedInputMethod))) {
+            $0.lastSwitchAttempt = nil
+            $0.$appRulesStore.withLock {
+                guard var rule = $0.rules[bundleId] else { return }
+                rule.strategy = .followLast(lastInputMethodId: failedInputMethod)
+                rule.updatedAt = updateDate
+                $0.rules[bundleId] = rule
+            }
+        }
+
+        XCTAssertNil(store.state.inputMethodDiagnostic)
+        XCTAssertEqual(
+            store.state.appRules[bundleId]?.strategy,
+            .followLast(lastInputMethodId: failedInputMethod)
+        )
         XCTAssertEqual(store.state.appSwitchStatisticsStore.counts[bundleId], 2)
     }
 

--- a/TypeSwitchTests/SupportDiagnosticsTests.swift
+++ b/TypeSwitchTests/SupportDiagnosticsTests.swift
@@ -9,7 +9,8 @@ final class SupportDiagnosticsTests: XCTestCase {
             build: "45",
             operatingSystemVersion: "macOS 15.6 (24G84)",
             architecture: "arm64",
-            appLanguage: "zh-Hans"
+            appLanguage: "zh-Hans",
+            localeIdentifier: "en_US"
         )
 
         XCTAssertEqual(
@@ -20,6 +21,7 @@ final class SupportDiagnosticsTests: XCTestCase {
             macOS: macOS 15.6 (24G84)
             Architecture: arm64
             App Language: zh-Hans
+            Locale: en_US
             """
         )
     }
@@ -31,6 +33,7 @@ final class SupportDiagnosticsTests: XCTestCase {
             operatingSystemVersion: "macOS 15.6 (24G84)",
             architecture: "arm64",
             appLanguage: "zh-Hans",
+            localeIdentifier: "zh_Hans_CN",
             diagnosticCategory: "switchFailed",
             errorDescription: "Could not verify the selected input method"
         )
@@ -43,6 +46,7 @@ final class SupportDiagnosticsTests: XCTestCase {
             macOS: macOS 15.6 (24G84)
             Architecture: arm64
             App Language: zh-Hans
+            Locale: zh_Hans_CN
             Diagnostic category: switchFailed
             Error description: Could not verify the selected input method
             """
@@ -55,14 +59,16 @@ final class SupportDiagnosticsTests: XCTestCase {
             build: "45",
             operatingSystemVersion: "macOS 15.6 (24G84)",
             architecture: "arm64",
-            appLanguage: "en"
+            appLanguage: "en",
+            localeIdentifier: "en_US"
         )
         let missingBuild = SupportDiagnostics(
             version: "1.2.3",
             build: "",
             operatingSystemVersion: "macOS 15.6 (24G84)",
             architecture: "arm64",
-            appLanguage: "en"
+            appLanguage: "en",
+            localeIdentifier: "en_US"
         )
 
         XCTAssertEqual(missingVersion.version, "–")
@@ -79,11 +85,27 @@ final class SupportDiagnosticsTests: XCTestCase {
             build: "45",
             operatingSystemVersion: "macOS 15.6 (24G84)",
             architecture: "arm64",
-            appLanguage: nil
+            appLanguage: nil,
+            localeIdentifier: "en_US"
         )
 
         XCTAssertEqual(diagnostics.appLanguage, "–")
-        XCTAssertTrue(diagnostics.reportText.contains("App Language: –"))
+        XCTAssertEqual(diagnostics.localeIdentifier, "en_US")
+        XCTAssertTrue(diagnostics.reportText.contains("App Language: –\nLocale: en_US"))
+    }
+
+    func testMissingLocaleUsesPlaceholder() {
+        let diagnostics = SupportDiagnostics(
+            version: "1.2.3",
+            build: "45",
+            operatingSystemVersion: "macOS 15.6 (24G84)",
+            architecture: "arm64",
+            appLanguage: "en",
+            localeIdentifier: nil
+        )
+
+        XCTAssertEqual(diagnostics.localeIdentifier, "–")
+        XCTAssertTrue(diagnostics.reportText.contains("App Language: en\nLocale: –"))
     }
 
     func testReportIssueURLUsesBugReportTemplate() throws {

--- a/script/ensure_release_absent.sh
+++ b/script/ensure_release_absent.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" -ne 2 ]]; then
+  echo "Usage: script/ensure_release_absent.sh <repository> <tag>" >&2
+  exit 1
+fi
+
+repository="$1"
+tag="$2"
+response_file=$(mktemp)
+trap 'rm -f "$response_file"' EXIT
+
+set +e
+gh api --include --silent "repos/${repository}/releases/tags/${tag}" >"$response_file" 2>&1
+gh_status=$?
+set -e
+
+http_status=$(awk '
+  $1 ~ /^HTTP\// && $2 ~ /^[0-9][0-9][0-9]$/ { status = $2 }
+  END { print status }
+' "$response_file")
+
+case "$http_status" in
+  404)
+    echo "No existing GitHub Release found for ${tag}."
+    ;;
+  200)
+    echo "GitHub Release ${repository}@${tag} already exists; create a new SemVer tag instead." >&2
+    exit 1
+    ;;
+  "")
+    echo "Could not verify whether GitHub Release ${repository}@${tag} exists (gh exited ${gh_status})." >&2
+    cat "$response_file" >&2
+    exit 1
+    ;;
+  *)
+    echo "Could not verify whether GitHub Release ${repository}@${tag} exists (HTTP ${http_status})." >&2
+    cat "$response_file" >&2
+    exit 1
+    ;;
+esac

--- a/script/test_release_scripts.sh
+++ b/script/test_release_scripts.sh
@@ -6,6 +6,7 @@ ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
 VERIFY_SCRIPT="${ROOT_DIR}/script/verify_release.sh"
 CASK_SCRIPT="${ROOT_DIR}/script/update_homebrew_cask.rb"
 ORDER_SCRIPT="${ROOT_DIR}/script/validate_release_order.rb"
+RELEASE_ABSENT_SCRIPT="${ROOT_DIR}/script/ensure_release_absent.sh"
 TEST_DIR=$(mktemp -d)
 trap 'rm -rf "$TEST_DIR"' EXIT
 
@@ -113,6 +114,52 @@ EOF
 chmod +x "${TEST_DIR}/bin/sign_update"
 export SPARKLE_SIGN_UPDATE="${TEST_DIR}/bin/sign_update"
 
+cat > "${TEST_DIR}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ "$#" == 4 ]] || exit 99
+[[ "$1" == "api" && "$2" == "--include" && "$3" == "--silent" ]] || exit 99
+[[ "$4" == "repos/ygsgdbd/TypeSwitch/releases/tags/v1.2.3" ]] || exit 99
+
+case "${GH_STUB_MODE:-}" in
+  404)
+    printf 'HTTP/2.0 404 Not Found\n\n'
+    exit 1
+    ;;
+  200)
+    printf 'HTTP/2.0 200 OK\n\n'
+    ;;
+  403)
+    printf 'HTTP/2.0 403 Forbidden\n\n'
+    exit 1
+    ;;
+  429)
+    printf 'HTTP/2.0 429 Too Many Requests\n\n'
+    exit 1
+    ;;
+  500)
+    printf 'HTTP/2.0 500 Internal Server Error\n\n'
+    exit 1
+    ;;
+  network)
+    echo 'network unavailable' >&2
+    exit 1
+    ;;
+  *)
+    exit 98
+    ;;
+esac
+EOF
+chmod +x "${TEST_DIR}/bin/gh"
+
+PATH="${TEST_DIR}/bin:${PATH}" GH_STUB_MODE=404 \
+  "$RELEASE_ABSENT_SCRIPT" ygsgdbd/TypeSwitch v1.2.3 >/dev/null
+for stub_mode in 200 403 429 500 network; do
+  assert_fails env PATH="${TEST_DIR}/bin:${PATH}" GH_STUB_MODE="$stub_mode" \
+    "$RELEASE_ABSENT_SCRIPT" ygsgdbd/TypeSwitch v1.2.3
+done
+
 ARTIFACTS="${TEST_DIR}/artifacts"
 make_artifacts "$ARTIFACTS" v1.2.3
 PATH="${TEST_DIR}/bin:${PATH}" "$VERIFY_SCRIPT" v1.2.3 "$ARTIFACTS" >/dev/null
@@ -171,6 +218,9 @@ end
 EOF
 
 ruby "$CASK_SCRIPT" "$CASK" v1.2.4 "$SHA" >/dev/null
+assert_contains "$CASK" '  version "1.2.4"'
+assert_contains "$CASK" "  sha256 \"${SHA}\""
+assert_contains "$CASK" '  url "https://github.com/ygsgdbd/TypeSwitch/releases/download/v1.2.4/TypeSwitch-macOS-universal.zip"'
 EXPECTED_CASK=$(cat "$CASK")
 ruby "$CASK_SCRIPT" "$CASK" v1.2.4 "$SHA" >/dev/null
 [[ "$(cat "$CASK")" == "$EXPECTED_CASK" ]] || fail "Cask updater is not idempotent."
@@ -200,6 +250,7 @@ assert_contains "$WORKFLOW" 'group: release-${{ github.repository }}'
 assert_contains "$WORKFLOW" 'queue: max'
 assert_contains "$WORKFLOW" "git tag --merged origin/main --list 'v*'"
 assert_contains "$WORKFLOW" 'ruby script/validate_release_order.rb "$RELEASE_TAG"'
+assert_contains "$WORKFLOW" 'script/ensure_release_absent.sh "$GITHUB_REPOSITORY" "$RELEASE_TAG"'
 assert_contains "$WORKFLOW" 'cp release-notes.md DerivedData/SparkleFeed/TypeSwitch-macOS-universal.md'
 assert_contains "$WORKFLOW" '--embed-release-notes'
 assert_contains "$WORKFLOW" 'script/verify_release.sh "$RELEASE_TAG" .'
@@ -215,6 +266,13 @@ assert_not_contains "$WORKFLOW" 'gh api markdown'
 assert_not_contains "$WORKFLOW" 'release-notes.html'
 [[ "$(grep -Fc 'secrets.HOMEBREW_TAP_TOKEN' "$WORKFLOW")" == "1" ]] || fail "Homebrew token must appear only in the tap checkout."
 [[ ! -e "${ROOT_DIR}/script/validate_release_version.rb" ]] || fail "Obsolete release version helper still exists."
+
+VALIDATE_TAG_LINE=$(grep -nF -- 'name: Validate release tag' "$WORKFLOW" | cut -d: -f1)
+RELEASE_ABSENT_LINE=$(grep -nF -- 'name: Ensure GitHub Release does not already exist' "$WORKFLOW" | cut -d: -f1)
+GENERATE_PROJECT_LINE=$(grep -nF -- 'name: Generate Xcode Project' "$WORKFLOW" | cut -d: -f1)
+if (( VALIDATE_TAG_LINE >= RELEASE_ABSENT_LINE || RELEASE_ABSENT_LINE >= GENERATE_PROJECT_LINE )); then
+  fail "GitHub Release absence check must run after tag validation and before project generation."
+fi
 
 assert_contains "$PR_WORKFLOW" 'release-scripts:'
 assert_contains "$PR_WORKFLOW" 'run: script/test_release_scripts.sh'


### PR DESCRIPTION
## Summary

This change resolves the six P2/P3 findings recorded in `Documentation/CodeReview-2026-08-17.md`: support diagnostics lacked locale context, stale input-method failures could reappear after a follow-last round trip, VoiceOver warnings replaced the current app state, same-tag release reruns could rebuild immutable assets, the Homebrew updater test did not verify its first result, and the changelog described a removed Homebrew permission preflight.

## User impact and root causes

Support reports could not distinguish the app language from the system locale, making regional formatting and sorting problems harder to diagnose. A failed follow-last switch remained in state when the user temporarily selected another input method, so selecting the failed target again could revive an obsolete warning. The menu bar accessibility label returned early for diagnostics, preventing VoiceOver from announcing whether the current app was configured, unconfigured, or ignored.

The release workflow generated a timestamped build on every run while refusing to overwrite existing assets. Rerunning a tag after a partial publication could therefore produce a new checksum and release body for old downloadable assets. The existing Homebrew fixture then captured the updater's first output as its expected value, allowing incomplete SHA or URL updates to pass as long as the second run was idempotent.

## Changes

- Add `Locale.current.identifier` to copied support diagnostics, with explicit app-language and locale fields and placeholder coverage.
- Clear matching failed switch attempts independently of the pre-update follow-last target, and add the A-failure to B to A regression test.
- Add warning-first VoiceOver labels for configured, unconfigured, and ignored apps across Base, English, Simplified Chinese, and Traditional Chinese resources.
- Add `script/ensure_release_absent.sh`; the release workflow now proceeds only when the GitHub Release-by-tag endpoint returns 404 and fails closed for existing releases, authorization/rate-limit/server errors, and network failures.
- Assert the Homebrew updater's first version, SHA-256, and URL result before checking idempotence.
- Correct the bilingual changelog and mark the audit findings as handled with updated verification counts.

## Validation

- `rtk just check`
  - SwiftFormat: 0 of 44 files require formatting
  - macOS XCTest: 131 tests, 0 failures
  - release script tests: passed
- `rtk git diff --cached --check`
- Mutation verification: disabling each Homebrew version, SHA, or URL replacement independently caused the new test assertion to fail; the restored implementation passed again.
- Live read-only GitHub API verification: a nonexistent release tag was allowed and existing release `v0.9.0` was rejected.

Manual VoiceOver listening verification was not performed; the localized label values and warning-first branch selection are covered by tests.
