### PR TITLE
fix(release): preserve annotated tag during checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Restore annotated release tag
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: git fetch --force origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+
       - name: Validate release tag
         id: release_tag
         env:

--- a/script/test_release_scripts.sh
+++ b/script/test_release_scripts.sh
@@ -275,6 +275,7 @@ JOB_NAMES=$(awk '
 assert_contains "$WORKFLOW" 'group: release-${{ github.repository }}'
 assert_contains "$WORKFLOW" 'cancel-in-progress: false'
 assert_not_contains "$WORKFLOW" 'queue:'
+assert_contains "$WORKFLOW" 'git fetch --force origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"'
 assert_contains "$WORKFLOW" "git tag --merged origin/main --list 'v*'"
 assert_contains "$WORKFLOW" 'ruby script/validate_release_order.rb "$RELEASE_TAG"'
 assert_contains "$WORKFLOW" 'script/ensure_release_absent.sh "$GITHUB_REPOSITORY" "$RELEASE_TAG"'
@@ -294,11 +295,14 @@ assert_not_contains "$WORKFLOW" 'release-notes.html'
 [[ "$(grep -Fc 'secrets.HOMEBREW_TAP_TOKEN' "$WORKFLOW")" == "1" ]] || fail "Homebrew token must appear only in the tap checkout."
 [[ ! -e "${ROOT_DIR}/script/validate_release_version.rb" ]] || fail "Obsolete release version helper still exists."
 
+RESTORE_TAG_LINE=$(grep -nF -- 'name: Restore annotated release tag' "$WORKFLOW" | cut -d: -f1)
 VALIDATE_TAG_LINE=$(grep -nF -- 'name: Validate release tag' "$WORKFLOW" | cut -d: -f1)
 RELEASE_ABSENT_LINE=$(grep -nF -- 'name: Ensure GitHub Release does not already exist' "$WORKFLOW" | cut -d: -f1)
 GENERATE_PROJECT_LINE=$(grep -nF -- 'name: Generate Xcode Project' "$WORKFLOW" | cut -d: -f1)
-if (( VALIDATE_TAG_LINE >= RELEASE_ABSENT_LINE || RELEASE_ABSENT_LINE >= GENERATE_PROJECT_LINE )); then
-  fail "GitHub Release absence check must run after tag validation and before project generation."
+if (( RESTORE_TAG_LINE >= VALIDATE_TAG_LINE
+  || VALIDATE_TAG_LINE >= RELEASE_ABSENT_LINE
+  || RELEASE_ABSENT_LINE >= GENERATE_PROJECT_LINE )); then
+  fail "Annotated tag restore and release absence checks must run before project generation."
 fi
 
 assert_contains "$PR_WORKFLOW" 'release-scripts:'


### PR DESCRIPTION
## Summary

- restore the remote annotated tag object after `actions/checkout` rewrites the local tag ref to the peeled commit
- require that restore step to run before release-tag validation

## Root cause

The `v0.10.0` tag is annotated on GitHub, but release run `33594391034` showed `actions/checkout@v4` fetching the peeled commit into `refs/tags/v0.10.0`. The subsequent `git cat-file -t` therefore reported `commit` and stopped the release before any artifact or GitHub Release was created.

## Verification

- reproduced the checkout ref overwrite in an isolated temporary repository (`tag` -> `commit`)
- verified the restore fetch changes it back to `tag` while `v0.10.0^{}` remains `1de88bc6d5a74598d27c2e1cf6830b248a3c0a0a`
- `rtk just check` (SwiftFormat, 131 XCTest, release-script tests)
- `rtk actionlint .github/workflows/*.yml`
- `rtk git diff --check`

## Release recovery

No `v0.10.0` GitHub Release exists. After this PR is green and merged, the failed release will require a deliberate tag recovery because rerunning the old workflow would use the workflow definition from the original tag commit.
