### PR TITLE
[codex] fix update menu tracking crash

### DIFF
--- a/TypeSwitch/Sources/App/TypeSwitchApp.swift
+++ b/TypeSwitch/Sources/App/TypeSwitchApp.swift
@@ -59,6 +59,7 @@ struct TypeSwitchApp: App {
                         }
                     }
                     guard MenuBarView.isRootMenuTrackingNotification(notification) else { return }
+                    updateMonitor.menuTrackingDidBegin()
                     store.send(.menuPresented)
                 }
             },
@@ -69,6 +70,7 @@ struct TypeSwitchApp: App {
             ) { notification in
                 MainActor.assumeIsolated {
                     guard MenuBarView.isRootMenuTrackingNotification(notification) else { return }
+                    updateMonitor.menuTrackingDidEnd()
                     store.send(.menuDismissed)
                 }
             },

--- a/TypeSwitch/Sources/Services/Updates/SparkleUpdateMonitor.swift
+++ b/TypeSwitch/Sources/Services/Updates/SparkleUpdateMonitor.swift
@@ -38,68 +38,91 @@ final class SparkleUpdateMonitor: NSObject, ObservableObject {
     }
 
     private var availableVersionBeforeCheck: String?
+    private var canonicalStatus: Status = .idle
+    private var isMenuTracking = false
     private var pendingVersion: String?
 
     func startSilentCheck(using updater: SparkleUpdateChecking) {
-        guard status != .checking, !updater.sessionInProgress else { return }
+        guard canonicalStatus != .checking, !updater.sessionInProgress else { return }
 
         beginCheck()
         updater.checkForUpdateInformation()
     }
 
     func showUpdate(using updater: SparkleUpdateChecking) {
-        guard status != .checking, updater.canCheckForUpdates else { return }
+        guard canonicalStatus != .checking, updater.canCheckForUpdates else { return }
 
         updater.checkForUpdates()
     }
 
+    func menuTrackingDidBegin() {
+        isMenuTracking = true
+    }
+
+    func menuTrackingDidEnd() {
+        guard isMenuTracking else { return }
+        isMenuTracking = false
+        publishCanonicalStatus()
+    }
+
     private var availableVersion: String? {
-        guard case .updateAvailable(let version) = status else { return nil }
+        guard case .updateAvailable(let version) = canonicalStatus else { return nil }
         return version
     }
 
     private func beginCheck() {
-        guard status != .checking else { return }
+        guard canonicalStatus != .checking else { return }
 
         availableVersionBeforeCheck = availableVersion
         pendingVersion = nil
-        status = .checking
+        setCanonicalStatus(.checking)
     }
 
     private func recordAvailableUpdate(_ update: SUAppcastItem) {
         let version = update.displayVersionString
-        if status == .checking {
+        if canonicalStatus == .checking {
             pendingVersion = version
         } else {
-            status = .updateAvailable(version: version)
+            setCanonicalStatus(.updateAvailable(version: version))
         }
     }
 
     func handleScheduledUpdate(_ update: SUAppcastItem) {
         availableVersionBeforeCheck = nil
         pendingVersion = nil
-        status = .updateAvailable(version: update.displayVersionString)
+        setCanonicalStatus(.updateAvailable(version: update.displayVersionString))
     }
 
     private func finishCheck(error: Error?) {
-        guard status == .checking else { return }
+        guard canonicalStatus == .checking else { return }
 
         if isNoUpdateError(error) {
-            status = .idle
+            setCanonicalStatus(.idle)
         } else if error != nil {
             if let availableVersionBeforeCheck {
-                status = .updateAvailable(version: availableVersionBeforeCheck)
+                setCanonicalStatus(.updateAvailable(version: availableVersionBeforeCheck))
             } else {
-                status = .idle
+                setCanonicalStatus(.idle)
             }
         } else if let pendingVersion {
-            status = .updateAvailable(version: pendingVersion)
+            setCanonicalStatus(.updateAvailable(version: pendingVersion))
         } else {
-            status = .idle
+            setCanonicalStatus(.idle)
         }
 
         availableVersionBeforeCheck = nil
         pendingVersion = nil
+    }
+
+    private func setCanonicalStatus(_ newStatus: Status) {
+        canonicalStatus = newStatus
+        guard !isMenuTracking else { return }
+        publishCanonicalStatus()
+    }
+
+    private func publishCanonicalStatus() {
+        guard status != canonicalStatus else { return }
+        status = canonicalStatus
     }
 
     private func isNoUpdateError(_ error: Error?) -> Bool {

--- a/TypeSwitchTests/SparkleUpdateMonitorTests.swift
+++ b/TypeSwitchTests/SparkleUpdateMonitorTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Sparkle
 @testable import TypeSwitch
 import XCTest
@@ -71,6 +72,60 @@ final class SparkleUpdateMonitorTests: XCTestCase {
         )
     }
 
+    func testFinishingCheckWhileMenuIsTrackedDefersVisibleStateUntilTrackingEnds() {
+        let updater = UpdaterSpy()
+        let monitor = SparkleUpdateMonitor()
+        monitor.startSilentCheck(using: updater)
+        monitor.menuTrackingDidBegin()
+
+        monitor.updater(
+            delegateUpdater,
+            didFinishUpdateCycleFor: .updateInformation,
+            error: noUpdateError
+        )
+
+        XCTAssertEqual(monitor.status, .checking)
+        XCTAssertEqual(
+            monitor.menuTitle,
+            TypeSwitchStrings.Settings.General.checkingForUpdates
+        )
+        XCTAssertFalse(monitor.isMenuActionEnabled)
+
+        monitor.menuTrackingDidEnd()
+
+        XCTAssertEqual(monitor.status, .idle)
+        XCTAssertEqual(
+            monitor.menuTitle,
+            TypeSwitchStrings.Settings.General.checkForUpdates
+        )
+        XCTAssertTrue(monitor.isMenuActionEnabled)
+    }
+
+    func testMenuTrackingPublishesOnlyFinalStatusWhenTrackingEnds() {
+        let updater = UpdaterSpy()
+        let monitor = SparkleUpdateMonitor()
+        let update = SUAppcastItem.empty()
+        monitor.startSilentCheck(using: updater)
+        var publishedStatuses: [SparkleUpdateMonitor.Status] = []
+        let cancellable = monitor.$status.dropFirst().sink {
+            publishedStatuses.append($0)
+        }
+        monitor.menuTrackingDidBegin()
+
+        monitor.updater(delegateUpdater, didFindValidUpdate: update)
+        monitor.updater(delegateUpdater, didFinishUpdateCycleFor: .updateInformation, error: nil)
+
+        XCTAssertTrue(publishedStatuses.isEmpty)
+
+        monitor.menuTrackingDidEnd()
+
+        XCTAssertEqual(
+            publishedStatuses,
+            [.updateAvailable(version: update.displayVersionString)]
+        )
+        withExtendedLifetime(cancellable) {}
+    }
+
     func testNoUpdateClearsPreviouslyKnownUpdate() {
         let updater = UpdaterSpy()
         let monitor = SparkleUpdateMonitor()
@@ -98,6 +153,30 @@ final class SparkleUpdateMonitorTests: XCTestCase {
             didFinishUpdateCycleFor: .updateInformation,
             error: NSError(domain: "SparkleUpdateMonitorTests", code: 1)
         )
+
+        XCTAssertEqual(
+            monitor.status,
+            .updateAvailable(version: update.displayVersionString)
+        )
+    }
+
+    func testFailedCheckWhileMenuIsTrackedRestoresKnownUpdateAfterTrackingEnds() {
+        let updater = UpdaterSpy()
+        let monitor = SparkleUpdateMonitor()
+        let update = SUAppcastItem.empty()
+        monitor.handleScheduledUpdate(update)
+        monitor.startSilentCheck(using: updater)
+        monitor.menuTrackingDidBegin()
+
+        monitor.updater(
+            delegateUpdater,
+            didFinishUpdateCycleFor: .updateInformation,
+            error: NSError(domain: "SparkleUpdateMonitorTests", code: 1)
+        )
+
+        XCTAssertEqual(monitor.status, .checking)
+
+        monitor.menuTrackingDidEnd()
 
         XCTAssertEqual(
             monitor.status,
@@ -161,6 +240,41 @@ final class SparkleUpdateMonitorTests: XCTestCase {
         )
 
         XCTAssertEqual(monitor.status, .idle)
+        XCTAssertTrue(monitor.isMenuActionEnabled)
+    }
+
+    func testScheduledUpdateWhileMenuIsTrackedDefersVisibleStateUntilTrackingEnds() {
+        let updater = UpdaterSpy()
+        let monitor = SparkleUpdateMonitor()
+        let update = SUAppcastItem.empty()
+        monitor.menuTrackingDidBegin()
+
+        XCTAssertNoThrow(
+            try monitor.updater(delegateUpdater, mayPerform: .updatesInBackground)
+        )
+        monitor.showUpdate(using: updater)
+        monitor.updater(delegateUpdater, didFindValidUpdate: update)
+        monitor.handleScheduledUpdate(update)
+        monitor.updater(delegateUpdater, didFinishUpdateCycleFor: .updatesInBackground, error: nil)
+
+        XCTAssertEqual(monitor.status, .idle)
+        XCTAssertEqual(
+            monitor.menuTitle,
+            TypeSwitchStrings.Settings.General.checkForUpdates
+        )
+        XCTAssertTrue(monitor.isMenuActionEnabled)
+        XCTAssertEqual(updater.userCheckCount, 0)
+
+        monitor.menuTrackingDidEnd()
+
+        XCTAssertEqual(
+            monitor.status,
+            .updateAvailable(version: update.displayVersionString)
+        )
+        XCTAssertEqual(
+            monitor.menuTitle,
+            TypeSwitchStrings.Settings.General.updateAvailable(update.displayVersionString)
+        )
         XCTAssertTrue(monitor.isMenuActionEnabled)
     }
 


### PR DESCRIPTION
## Summary

Fix a potential launch-time crash when a Sparkle update check finishes while TypeSwitch's native menu-bar menu is open.

## User impact and root cause

TypeSwitch starts a silent Sparkle update check at launch and renders its menu with `MenuBarExtra(.menu)`. The update monitor previously published status changes immediately. If an update callback changed the check-for-updates title or enabled state while AppKit was tracking the open menu, SwiftUI could rebuild the native menu in the middle of the tracking session and enter the same recursive menu update path observed in ListenBar.

Users could therefore see TypeSwitch terminate after launching it and immediately opening the menu, especially when the update request completed while the menu remained visible.

## Fix

The update monitor now keeps an internal canonical status separate from the published menu-visible status. Sparkle callbacks continue to update the canonical state immediately, while visible status publication is frozen during root-menu tracking. When tracking ends, the monitor publishes only the final state and skips redundant publications.

The existing root `NSMenu` begin/end observers now notify the update monitor. Submenu notifications remain filtered out, and all state-machine guards use canonical state so a visually frozen menu cannot start a duplicate interactive check.

## Validation

- Added regression coverage for no-update completion while tracking.
- Added publisher assertions proving zero publications during tracking and one final publication after dismissal.
- Covered available updates, background scheduled checks, manual-check suppression, and failure restoration of a previously known version.
- Ran `just check`, including SwiftFormat lint, the complete macOS XCTest suite, and release-script tests.
- Ran `git diff --check`.
