### PR TITLE
[codex] prepare v0.10.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.10.1
+
+### 🇨🇳 中文
+
+#### 修复
+
+- 修复更新检查状态在菜单展开期间变化时可能导致 TypeSwitch 闪退的问题；更新状态会延迟到菜单关闭后再显示。
+
+### 🇺🇸 English
+
+#### Fixes
+
+- Fixed a crash that could occur when the update-check status changed while the menu was open; the visible status is now deferred until the menu closes.
+
 ## v0.10.0
 
 ### 🇨🇳 中文


### PR DESCRIPTION
## Summary

Prepare the v0.10.1 patch release with bilingual release notes for the menu-tracking crash fix merged in #43.

## Release scope

- Fix a potential crash when Sparkle update-check status changes while the native menu is open.
- Defer the visible update status until menu tracking ends.
- No application code, public API, project version, or update configuration changes in this release-preparation PR.

## Validation

- `rtk just check`
- `git diff --check`
- Confirmed `v0.10.0..origin/main` contains only #43 before preparing the release.
- Confirmed the `v0.10.1` tag and GitHub Release do not exist.

## Release procedure

After this PR is merged and all checks pass, create the annotated `v0.10.1` tag on the merged `origin/main` commit and verify the GitHub Release, Sparkle appcast, Artifact Attestation, and Homebrew cask.
